### PR TITLE
Task/FP-369: Add Compress/Extract Buttons

### DIFF
--- a/client/src/components/DataFiles/DataFilesModals/DataFilesCompressModal.js
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesCompressModal.js
@@ -16,6 +16,7 @@ import { isString, chain } from 'lodash';
 import { Formik } from 'formik';
 import PropTypes from 'prop-types';
 import * as yup from 'yup';
+import './DataFilesCompressModal.module.scss';
 
 const DataFilesCompressForm = ({ first, formRef }) => {
   const initialValues = {
@@ -167,14 +168,12 @@ const DataFilesCompressModal = () => {
           onClick={compressCallback}
           className="data-files-btn"
           disabled={status === 'RUNNING'}
-          style={{ display: 'flex' }}
+          styleName="submit-button"
         >
-          {status === 'RUNNING' && (
-            <>
-              <LoadingSpinner placement="inline" />{' '}
-            </>
-          )}
-          <span>Compress</span>
+          {status === 'RUNNING' && <LoadingSpinner placement="inline" />}
+          <span styleName={status === 'RUNNING' ? 'with-spinner' : ''}>
+            Compress
+          </span>
         </Button>
         <Button
           color="secondary"

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesCompressModal.js
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesCompressModal.js
@@ -1,0 +1,78 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { useSelector, useDispatch, shallowEqual } from 'react-redux';
+import { Button, Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
+
+const DataFilesCompressModal = () => {
+  const [disabled, setDisabled] = useState(false);
+  const dispatch = useDispatch();
+
+  const params = useSelector(
+    state => state.files.params.FilesListing,
+    shallowEqual
+  );
+  const modalParams = useSelector(
+    state => state.files.params.modal,
+    shallowEqual
+  );
+  const isOpen = useSelector(state => state.files.modals.compress);
+  const selectedFiles = useSelector(({ files: { selected, listing } }) =>
+    selected.FilesListing.map(i => ({
+      ...listing.FilesListing[i]
+    }))
+  );
+  const selected = useMemo(() => selectedFiles, [isOpen]);
+
+  const toggle = () =>
+    dispatch({
+      type: 'DATA_FILES_TOGGLE_MODAL',
+      payload: { operation: 'compress', props: {} }
+    });
+
+  const onOpened = () => {
+    dispatch({
+      type: 'FETCH_FILES_MODAL',
+      payload: { ...params, section: 'modal' }
+    });
+    // TODO: Get Zippy!
+  };
+
+  const onClosed = () => {
+    dispatch({ type: 'DATA_FILES_MODAL_CLOSE' });
+    setDisabled(false);
+  };
+
+  const compressCallback = () => {
+    dispatch({
+      type: 'DATA_FILES_COMPRESS',
+      payload: { files: selected }
+    });
+  };
+
+  if (isOpen) console.log(selected, modalParams);
+  return (
+    <Modal
+      isOpen={isOpen}
+      onOpened={onOpened}
+      onClosed={onClosed}
+      toggle={toggle}
+      className="dataFilesModal"
+    >
+      <ModalHeader toggle={toggle}>Compressing</ModalHeader>
+      <ModalBody />
+      <ModalFooter>
+        <Button onClick={compressCallback} className="data-files-btn">
+          Compress
+        </Button>
+        <Button
+          color="secondary"
+          className="data-files-btn-cancel"
+          onClick={toggle}
+        >
+          Close
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+};
+
+export default DataFilesCompressModal;

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesCompressModal.module.scss
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesCompressModal.module.scss
@@ -1,0 +1,8 @@
+.submit-button {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.with-spinner {
+  margin-left: 0.75rem;
+}

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesExtractModal.js
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesExtractModal.js
@@ -4,6 +4,7 @@ import { Button, Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
 import { LoadingSpinner } from '_common';
 import { useHistory, useLocation } from 'react-router-dom';
 import { isString } from 'lodash';
+import './DataFilesCompressModal.module.scss';
 
 const DataFilesCompressModal = () => {
   const history = useHistory();
@@ -82,14 +83,12 @@ const DataFilesCompressModal = () => {
           onClick={extractCallback}
           className="data-files-btn"
           disabled={status === 'RUNNING'}
-          style={{ display: 'flex' }}
+          styleName="submit-button"
         >
-          {status === 'RUNNING' && (
-            <>
-              <LoadingSpinner placement="inline" />{' '}
-            </>
-          )}
-          <span>Extract</span>
+          {status === 'RUNNING' && <LoadingSpinner placement="inline" />}
+          <span styleName={status === 'RUNNING' ? 'with-spinner' : ''}>
+            Extract
+          </span>
         </Button>
         <Button
           color="secondary"

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesExtractModal.js
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesExtractModal.js
@@ -10,7 +10,7 @@ const DataFilesCompressModal = () => {
   const location = useLocation();
   const dispatch = useDispatch();
   const status = useSelector(
-    state => state.files.operationStatus.compress,
+    state => state.files.operationStatus.extract,
     shallowEqual
   );
 
@@ -19,7 +19,7 @@ const DataFilesCompressModal = () => {
     shallowEqual
   );
 
-  const isOpen = useSelector(state => state.files.modals.compress);
+  const isOpen = useSelector(state => state.files.modals.extract);
   const selectedFiles = useSelector(({ files: { selected, listing } }) =>
     selected.FilesListing.map(i => ({
       ...listing.FilesListing[i]
@@ -30,10 +30,9 @@ const DataFilesCompressModal = () => {
   const toggle = () =>
     dispatch({
       type: 'DATA_FILES_TOGGLE_MODAL',
-      payload: { operation: 'compress', props: {} }
+      payload: { operation: 'extract', props: {} }
     });
 
-  // TODO: Add listing of files to be compressed
   const onOpened = () => {
     dispatch({
       type: 'FETCH_FILES_MODAL',
@@ -46,19 +45,17 @@ const DataFilesCompressModal = () => {
     if (isString(status)) {
       dispatch({
         type: 'DATA_FILES_SET_OPERATION_STATUS',
-        payload: { status: {}, operation: 'compress' }
+        payload: { status: {}, operation: 'extract' }
       });
       history.push(location.pathname);
     }
   };
-
-  const compressCallback = () => {
+  const extractCallback = () => {
     dispatch({
-      type: 'DATA_FILES_COMPRESS',
-      payload: { files: selected }
+      type: 'DATA_FILES_EXTRACT',
+      payload: { file: selected[0] }
     });
   };
-
   return (
     <Modal
       isOpen={isOpen}
@@ -67,29 +64,28 @@ const DataFilesCompressModal = () => {
       toggle={toggle}
       className="dataFilesModal"
     >
-      <ModalHeader toggle={toggle}>Compress Files</ModalHeader>
+      <ModalHeader toggle={toggle}>Extract Files</ModalHeader>
       <ModalBody>
-        {/* TODO: Form for filename and filetype */}
         <p>
-          A job to compress your files will be submitted on your behalf. You can
-          check the status of this job on your Dashboard, and your compressed
-          file will appear in this directory.
+          A job to extract your file will be submitted on your behalf. You can
+          check the status of this job on your Dashboard, and your extracted
+          files will appear in this directory.
         </p>
         {status === 'SUCCESS' && (
           <span style={{ color: 'green' }}>
-            Successfully started compress job
+            Successfully started extract job
           </span>
         )}
       </ModalBody>
       <ModalFooter>
         <Button
-          onClick={compressCallback}
+          onClick={extractCallback}
           className="data-files-btn"
           disabled={status === 'RUNNING'}
           style={{ display: 'flex' }}
         >
           {status === 'RUNNING' && <LoadingSpinner placement="inline" />}
-          <span>Compress</span>
+          <span>Extract</span>
         </Button>
         <Button
           color="secondary"

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesExtractModal.js
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesExtractModal.js
@@ -84,7 +84,11 @@ const DataFilesCompressModal = () => {
           disabled={status === 'RUNNING'}
           style={{ display: 'flex' }}
         >
-          {status === 'RUNNING' && <LoadingSpinner placement="inline" />}
+          {status === 'RUNNING' && (
+            <>
+              <LoadingSpinner placement="inline" />{' '}
+            </>
+          )}
           <span>Extract</span>
         </Button>
         <Button

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesModals.js
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesModals.js
@@ -7,6 +7,7 @@ import DataFilesRenameModal from './DataFilesRenameModal';
 import DataFilesPushKeysModal from './DataFilesPushKeysModal';
 import DataFilesCopyModal from './DataFilesCopyModal';
 import DataFilesTrashModal from './DataFilesTrashModal';
+import DataFilesCompressModal from './DataFilesCompressModal';
 import './DataFilesModals.scss';
 
 export default function DataFilesModals() {
@@ -20,6 +21,7 @@ export default function DataFilesModals() {
       <DataFilesRenameModal />
       <DataFilesPushKeysModal />
       <DataFilesTrashModal />
+      <DataFilesCompressModal />
     </>
   );
 }

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesModals.js
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesModals.js
@@ -8,6 +8,7 @@ import DataFilesPushKeysModal from './DataFilesPushKeysModal';
 import DataFilesCopyModal from './DataFilesCopyModal';
 import DataFilesTrashModal from './DataFilesTrashModal';
 import DataFilesCompressModal from './DataFilesCompressModal';
+import DataFilesExtractModal from './DataFilesExtractModal';
 import './DataFilesModals.scss';
 
 export default function DataFilesModals() {
@@ -22,6 +23,7 @@ export default function DataFilesModals() {
       <DataFilesPushKeysModal />
       <DataFilesTrashModal />
       <DataFilesCompressModal />
+      <DataFilesExtractModal />
     </>
   );
 }

--- a/client/src/components/DataFiles/DataFilesToolbar/DataFilesToolbar.js
+++ b/client/src/components/DataFiles/DataFilesToolbar/DataFilesToolbar.js
@@ -66,6 +66,16 @@ const DataFilesToolbar = ({ scheme }) => {
     });
   };
 
+  const toggleExtractModal = () => {
+    dispatch({
+      type: 'DATA_FILES_TOGGLE_MODAL',
+      payload: {
+        operation: 'extract',
+        props: { selectedFile: selectedFiles[0] }
+      }
+    });
+  };
+
   const download = () => {
     dispatch({
       type: 'DATA_FILES_DOWNLOAD',
@@ -87,10 +97,17 @@ const DataFilesToolbar = ({ scheme }) => {
     selectedFiles.length === 1 && selectedFiles[0].format !== 'folder';
   const canTrash = selectedFiles.length > 0 && scheme === 'private';
   const canCompress = selectedFiles.length > 0 && scheme === 'private';
+  const canExtract = canDownload && selectedFiles[0].name.includes('.zip');
 
   return (
     <>
       <div id="data-files-toolbar-button-row">
+        <ToolbarButton
+          text="Extract"
+          onClick={toggleExtractModal}
+          icon={{}}
+          disabled={!canExtract}
+        />
         <ToolbarButton
           text="Compress"
           onClick={toggleCompressModal}

--- a/client/src/components/DataFiles/DataFilesToolbar/DataFilesToolbar.js
+++ b/client/src/components/DataFiles/DataFilesToolbar/DataFilesToolbar.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Button } from 'reactstrap';
+import getFilePermissions from 'utils/filePermissions';
 import './DataFilesToolbar.scss';
 
 export const ToolbarButton = ({ text, iconName, onClick, disabled }) => {
@@ -13,7 +14,7 @@ export const ToolbarButton = ({ text, iconName, onClick, disabled }) => {
       onClick={onClick}
       className="data-files-toolbar-button"
     >
-      <i className={iconClassName} data-testid="toolbar-icon" />
+      {iconName && <i className={iconClassName} data-testid="toolbar-icon" />}
       <span className="toolbar-button-text">{text}</span>
     </Button>
   );
@@ -90,18 +91,14 @@ const DataFilesToolbar = ({ scheme }) => {
     });
   };
 
-  const canRename = selectedFiles.length === 1 && scheme === 'private';
-  const canMove = selectedFiles.length > 0 && scheme === 'private';
-  const canCopy = selectedFiles.length > 0 && scheme === 'private';
-  const canDownload =
-    selectedFiles.length === 1 && selectedFiles[0].format !== 'folder';
-  const canTrash = selectedFiles.length > 0 && scheme === 'private';
-  const canCompress = selectedFiles.length > 0 && scheme === 'private';
-  const isArchive =
-    selectedFiles.length > 0 &&
-    (selectedFiles[0].name.includes('.zip') ||
-      selectedFiles[0].name.includes('tar.gz'));
-  const canExtract = canDownload && isArchive;
+  const permissionParams = { files: selectedFiles, scheme };
+  const canRename = getFilePermissions('rename', permissionParams);
+  const canMove = getFilePermissions('move', permissionParams);
+  const canCopy = getFilePermissions('copy', permissionParams);
+  const canDownload = getFilePermissions('download', permissionParams);
+  const canTrash = getFilePermissions('trash', permissionParams);
+  const canCompress = getFilePermissions('compress', permissionParams);
+  const canExtract = getFilePermissions('extract', permissionParams);
 
   return (
     <>
@@ -109,13 +106,13 @@ const DataFilesToolbar = ({ scheme }) => {
         <ToolbarButton
           text="Extract"
           onClick={toggleExtractModal}
-          icon={{}}
+          iconName=""
           disabled={!canExtract}
         />
         <ToolbarButton
           text="Compress"
           onClick={toggleCompressModal}
-          icon={{}}
+          iconName=""
           disabled={!canCompress}
         />
         <ToolbarButton

--- a/client/src/components/DataFiles/DataFilesToolbar/DataFilesToolbar.js
+++ b/client/src/components/DataFiles/DataFilesToolbar/DataFilesToolbar.js
@@ -59,6 +59,13 @@ const DataFilesToolbar = ({ scheme }) => {
       payload: { operation: 'copy', props: { selectedFiles } }
     });
 
+  const toggleCompressModal = () => {
+    dispatch({
+      type: 'DATA_FILES_TOGGLE_MODAL',
+      payload: { operation: 'compress', props: { selectedFiles } }
+    });
+  };
+
   const download = () => {
     dispatch({
       type: 'DATA_FILES_DOWNLOAD',
@@ -79,10 +86,19 @@ const DataFilesToolbar = ({ scheme }) => {
   const canDownload =
     selectedFiles.length === 1 && selectedFiles[0].format !== 'folder';
   const canTrash = selectedFiles.length > 0 && scheme === 'private';
+  const canCompress = selectedFiles.length > 0;
 
   return (
     <>
       <div id="data-files-toolbar-button-row">
+        {canCompress && (
+          <ToolbarButton
+            text="Compress"
+            onClick={toggleCompressModal}
+            icon={{}}
+            disabled={false}
+          />
+        )}
         <ToolbarButton
           text="Rename"
           onClick={toggleRenameModal}

--- a/client/src/components/DataFiles/DataFilesToolbar/DataFilesToolbar.js
+++ b/client/src/components/DataFiles/DataFilesToolbar/DataFilesToolbar.js
@@ -86,19 +86,17 @@ const DataFilesToolbar = ({ scheme }) => {
   const canDownload =
     selectedFiles.length === 1 && selectedFiles[0].format !== 'folder';
   const canTrash = selectedFiles.length > 0 && scheme === 'private';
-  const canCompress = selectedFiles.length > 0;
+  const canCompress = selectedFiles.length > 0 && scheme === 'private';
 
   return (
     <>
       <div id="data-files-toolbar-button-row">
-        {canCompress && (
-          <ToolbarButton
-            text="Compress"
-            onClick={toggleCompressModal}
-            icon={{}}
-            disabled={false}
-          />
-        )}
+        <ToolbarButton
+          text="Compress"
+          onClick={toggleCompressModal}
+          icon={{}}
+          disabled={!canCompress}
+        />
         <ToolbarButton
           text="Rename"
           onClick={toggleRenameModal}

--- a/client/src/components/DataFiles/DataFilesToolbar/DataFilesToolbar.js
+++ b/client/src/components/DataFiles/DataFilesToolbar/DataFilesToolbar.js
@@ -97,7 +97,11 @@ const DataFilesToolbar = ({ scheme }) => {
     selectedFiles.length === 1 && selectedFiles[0].format !== 'folder';
   const canTrash = selectedFiles.length > 0 && scheme === 'private';
   const canCompress = selectedFiles.length > 0 && scheme === 'private';
-  const canExtract = canDownload && selectedFiles[0].name.includes('.zip');
+  const isArchive =
+    selectedFiles.length > 0 &&
+    (selectedFiles[0].name.includes('.zip') ||
+      selectedFiles[0].name.includes('tar.gz'));
+  const canExtract = canDownload && isArchive;
 
   return (
     <>

--- a/client/src/redux/reducers/datafiles.reducers.js
+++ b/client/src/redux/reducers/datafiles.reducers.js
@@ -61,7 +61,8 @@ const initialFilesState = {
     mkdir: false,
     rename: false,
     pushKeys: false,
-    trash: false
+    trash: false,
+    compress: false
   },
   modalProps: {
     preview: {},

--- a/client/src/redux/reducers/datafiles.reducers.js
+++ b/client/src/redux/reducers/datafiles.reducers.js
@@ -25,7 +25,8 @@ const initialFilesState = {
     select: {},
     upload: {},
     trash: {},
-    compress: {}
+    compress: {},
+    extract: {}
   },
   loadingScroll: {
     FilesListing: false,
@@ -63,7 +64,8 @@ const initialFilesState = {
     rename: false,
     pushKeys: false,
     trash: false,
-    compress: false
+    compress: false,
+    extract: false
   },
   modalProps: {
     preview: {},

--- a/client/src/redux/reducers/datafiles.reducers.js
+++ b/client/src/redux/reducers/datafiles.reducers.js
@@ -24,7 +24,8 @@ const initialFilesState = {
     copy: {},
     select: {},
     upload: {},
-    trash: {}
+    trash: {},
+    compress: {}
   },
   loadingScroll: {
     FilesListing: false,

--- a/client/src/redux/sagas/datafiles.sagas.js
+++ b/client/src/redux/sagas/datafiles.sagas.js
@@ -615,6 +615,7 @@ const getExtractParams = async file => {
     parameters: {}
   });
 };
+
 export function* extractFiles(action) {
   try {
     const params = yield call(getExtractParams, action.payload.file);
@@ -645,7 +646,7 @@ export function* watchExtract() {
 /**
  * Create JSON string of job params
  */
-const getCompressParams = async files => {
+const getCompressParams = async (files, zipfileName) => {
   const res = await fetchUtil({
     url: '/api/workspace/apps',
     params: { publicOnly: true }
@@ -667,7 +668,7 @@ const getCompressParams = async files => {
   };
   const parameters = {
     filenames: files.reduce((names, file) => `${names}"${file.name}" `, ''),
-    zipfileName: `${files[0].name}.zip`
+    zipfileName
   };
   const archivePath = `agave://${files[0].system}${files[0].path.substring(
     0,
@@ -688,7 +689,11 @@ const getCompressParams = async files => {
 
 export function* compressFiles(action) {
   try {
-    const params = yield call(getCompressParams, action.payload.files);
+    const params = yield call(
+      getCompressParams,
+      action.payload.files,
+      action.payload.filename
+    );
     yield put({
       type: 'DATA_FILES_SET_OPERATION_STATUS',
       payload: { status: 'RUNNING', operation: 'compress' }

--- a/client/src/redux/sagas/datafiles.sagas.js
+++ b/client/src/redux/sagas/datafiles.sagas.js
@@ -590,12 +590,19 @@ const getExtractParams = async file => {
     .filter(app => app.id.includes('extract-frontera'))
     .reduce(
       (latest, app) => {
-        if (app.revision > latest.revision) {
+        if (app.version > latest.version) {
+          return app;
+        }
+        if (app.version < latest.version) {
+          return latest;
+        }
+        // Same version of app
+        if (app.revision >= latest.revision) {
           return app;
         }
         return latest;
       },
-      { revision: null }
+      { revision: null, version: null }
     );
   const inputFile = `agave://${file.system}${file.path}`;
   const archivePath = `agave://${file.system}${file.path.substring(
@@ -645,6 +652,10 @@ export function* watchExtract() {
 
 /**
  * Create JSON string of job params
+ * @async
+ * @param {Array<Object>} files
+ * @param {String} zipfileName
+ * @returns {String}
  */
 const getCompressParams = async (files, zipfileName) => {
   const res = await fetchUtil({
@@ -656,12 +667,19 @@ const getCompressParams = async (files, zipfileName) => {
     .filter(app => app.id.includes('zippy-frontera'))
     .reduce(
       (latest, app) => {
-        if (app.revision > latest.revision) {
+        if (app.version > latest.version) {
+          return app;
+        }
+        if (app.version < latest.version) {
+          return latest;
+        }
+        // Same version of app
+        if (app.revision >= latest.revision) {
           return app;
         }
         return latest;
       },
-      { revision: null }
+      { revision: null, version: null }
     );
   const inputs = {
     inputFiles: files.map(file => `agave://${file.system}${file.path}`)
@@ -698,7 +716,7 @@ export function* compressFiles(action) {
       type: 'DATA_FILES_SET_OPERATION_STATUS',
       payload: { status: 'RUNNING', operation: 'compress' }
     });
-    const submission = yield call(jobHelper, params); // TODO: dispatch 'SUBMIT_JOB'
+    const submission = yield call(jobHelper, params);
     if (submission.status === 'ACCEPTED') {
       yield put({
         type: 'DATA_FILES_SET_OPERATION_STATUS',

--- a/client/src/redux/sagas/index.js
+++ b/client/src/redux/sagas/index.js
@@ -17,7 +17,8 @@ import {
   watchPreview,
   watchMkdir,
   watchDownload,
-  watchTrash
+  watchTrash,
+  watchCompress
 } from './datafiles.sagas';
 import watchAllocations from './allocations.sagas';
 import watchSystemMonitor from './systemMonitor.sagas';
@@ -50,6 +51,7 @@ export default function* rootSaga() {
     watchDownload(),
     watchTrash(),
     ...watchAllocations,
+    watchCompress(),
     watchApps(),
     watchSystems(),
     watchSystemMonitor(),

--- a/client/src/redux/sagas/index.js
+++ b/client/src/redux/sagas/index.js
@@ -18,7 +18,8 @@ import {
   watchMkdir,
   watchDownload,
   watchTrash,
-  watchCompress
+  watchCompress,
+  watchExtract
 } from './datafiles.sagas';
 import watchAllocations from './allocations.sagas';
 import watchSystemMonitor from './systemMonitor.sagas';
@@ -52,6 +53,7 @@ export default function* rootSaga() {
     watchTrash(),
     ...watchAllocations,
     watchCompress(),
+    watchExtract(),
     watchApps(),
     watchSystems(),
     watchSystemMonitor(),

--- a/client/src/utils/filePermissions.js
+++ b/client/src/utils/filePermissions.js
@@ -1,0 +1,24 @@
+/**
+ * Check permissions for a selected file or files
+ * @param {String} name
+ * @param {Array<Object>} files
+ * @param {String} scheme
+ * @returns {Boolean}
+ */
+export default function getFilePermissions(name, { files, scheme }) {
+  switch (name) {
+    case 'rename':
+      return files.length === 1 && scheme === 'private';
+    case 'download':
+      return files.length === 1 && files[0].format !== 'folder';
+    case 'extract':
+      return (
+        files.length === 1 &&
+        (files[0].name.includes('.zip') || files[0].name.includes('tar.gz')) &&
+        scheme === 'private'
+      );
+    // Move, Copy, Trash, Compress
+    default:
+      return files.length > 0 && scheme === 'private';
+  }
+}

--- a/client/src/utils/filePermissions.test.js
+++ b/client/src/utils/filePermissions.test.js
@@ -1,0 +1,27 @@
+import { default as getFilePermissions } from './filePermissions';
+
+const fixture = {
+  files: [
+    {
+      name: "test.tar.gz",
+      path: "/test/test.tar.gz",
+      lastModified: "2020-08-01T00:00:00-05:00",
+      system: "frontera.home.test",
+      type: "file",
+    },
+  ],
+  scheme: "private",
+};
+describe('getFilePermissions utility function', () => {
+  it.each([
+    "rename",
+    "download",
+    "extract",
+    "move",
+    "copy",
+    "trash",
+    "compress",
+  ])("Correctly evaluate %s permission", (pem) => {
+    expect(getFilePermissions(pem, fixture)).toEqual(true);
+  });
+})


### PR DESCRIPTION
## Overview: ##

This currently contains Compress functionality using the Zippy cli app as well as the Extract app. 

## PR Status: ##

* [X] Ready

## Related Jira tickets: ##

* [FP-369](https://jira.tacc.utexas.edu/browse/FP-369)

## Summary of Changes: ##

A new modal, toolbar button, and saga has been added to the data files section.

## Testing Steps: ##

- Select files and click compress in your data files section.
- Select a `.zip` or `tar.gz` file and click extract

## Notes: ##

Much of the logic is `getCompressParams` logic is borrowed from CEP v1.
Currently the `WATCH_COMPRESS` and `WATCH_EXTRACT` sagas don't leverage the apps or jobs sagas.

## TODO ##
- [ ] Synchronous Rejection
- [x] Check for latest zippy and extract
- [ ] Spinner Size
- [ ] `_common/Message` in the modals
- [ ] Extract Supported Extensions
- [x] Refactor Permissions