### PR TITLE
Pinning celery to 4.4.7 to resolve dependency issue

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -2,7 +2,7 @@ Django==2.2.7
 PyJWT==1.7.1
 agavepy==0.9.3
 cached-property==1.5.1
-celery==4.3.0
+celery==4.4.7
 certifi==2019.9.11
 channels==2.4.0
 channels-redis==2.4.1


### PR DESCRIPTION
## Overview: ##

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [FP-723](https://jira.tacc.utexas.edu/browse/FP-723)

## Summary of Changes: ##

## Testing Steps: ##
1. docker system prune -a
2. docker volume prune
3. docker image prune -a
4. make build
5. make start
6. Re-run collectstatic and migrate on frontera_prtl_cms and frontera_prtl_django

## UI Photos:

## Notes: ##

I believe an unpinned dependency in celery 4.3.0 was causing an import error related to vine, which resulted in other things (such as daphne) not working.