### PR TITLE
task/FP-500 - refactor onboarding settings

### DIFF
--- a/server/portal/apps/onboarding/execute.py
+++ b/server/portal/apps/onboarding/execute.py
@@ -72,7 +72,7 @@ def prepare_setup_steps(user):
     """
     extra_steps = getattr(settings, 'PORTAL_USER_ACCOUNT_SETUP_STEPS', [])
     for step in extra_steps:
-        setup_step = load_setup_step(user, step)
+        setup_step = load_setup_step(user, step['step'])
         if setup_step.last_event is None:
             setup_step.prepare()
 
@@ -85,7 +85,7 @@ def execute_setup_steps(username):
     extra_steps = getattr(settings, 'PORTAL_USER_ACCOUNT_SETUP_STEPS', [])
     for step in extra_steps:
         # Restore state of this setup step for this user
-        setup_step = load_setup_step(user, step)
+        setup_step = load_setup_step(user, step['step'])
 
         # Run step, if waiting for automatic execution
         # should have this state

--- a/server/portal/apps/onboarding/execute_unit_test.py
+++ b/server/portal/apps/onboarding/execute_unit_test.py
@@ -56,7 +56,11 @@ def test_prepare_setup_steps(authenticated_user, mocker, settings):
     """
     Test that a step is loaded and prepared for a user that does not have step history
     """
-    settings.PORTAL_USER_ACCOUNT_SETUP_STEPS = ['TestStep']
+    settings.PORTAL_USER_ACCOUNT_SETUP_STEPS = [
+        {
+            'step': 'TestStep'
+        }
+    ]
     mock_step = MagicMock(
         last_event=None
     )
@@ -109,7 +113,11 @@ def test_successful_step(settings, authenticated_user, mocker):
     """
     Test that a step that completes successfully is executed without error
     """
-    settings.PORTAL_USER_ACCOUNT_SETUP_STEPS = ['portal.apps.onboarding.steps.test_steps.MockProcessingCompleteStep']
+    settings.PORTAL_USER_ACCOUNT_SETUP_STEPS = [
+        {
+            'step': 'portal.apps.onboarding.steps.test_steps.MockProcessingCompleteStep'
+        }
+    ]
     mock_log_setup_state = mocker.patch('portal.apps.onboarding.execute.log_setup_state')
 
     prepare_setup_steps(authenticated_user)
@@ -138,8 +146,12 @@ def test_fail_step(settings, authenticated_user):
     should not execute due to the previous step failing.
     """
     settings.PORTAL_USER_ACCOUNT_SETUP_STEPS = [
-        'portal.apps.onboarding.steps.test_steps.MockProcessingFailStep',
-        'portal.apps.onboarding.steps.test_steps.MockProcessingCompleteStep'
+        {
+            'step': 'portal.apps.onboarding.steps.test_steps.MockProcessingFailStep'
+        },
+        {
+            'step': 'portal.apps.onboarding.steps.test_steps.MockProcessingCompleteStep'
+        }
     ]
     with pytest.raises(StepExecuteException):
         prepare_setup_steps(authenticated_user)
@@ -159,7 +171,9 @@ def test_error_step(settings, authenticated_user):
     Assert that when a setup step causes an error that the error is logged
     """
     settings.PORTAL_USER_ACCOUNT_SETUP_STEPS = [
-        'portal.apps.onboarding.steps.test_steps.MockErrorStep'
+        {
+            'step': 'portal.apps.onboarding.steps.test_steps.MockErrorStep'
+        }
     ]
     with pytest.raises(StepExecuteException):
         prepare_setup_steps(authenticated_user)
@@ -183,8 +197,12 @@ def test_userwait_step(settings, authenticated_user):
     should not execute due to the first one not being "COMPLETE".
     """
     settings.PORTAL_USER_ACCOUNT_SETUP_STEPS = [
-        'portal.apps.onboarding.steps.test_steps.MockUserStep',
-        'portal.apps.onboarding.steps.test_steps.MockProcessingCompleteStep'
+        {
+            'step': 'portal.apps.onboarding.steps.test_steps.MockUserStep'
+        },
+        {
+            'step': 'portal.apps.onboarding.steps.test_steps.MockProcessingCompleteStep'
+        }
     ]
     with pytest.raises(StepExecuteException):
         prepare_setup_steps(authenticated_user)
@@ -207,8 +225,12 @@ def test_sequence(settings, authenticated_user):
     MockProcessingFailStep should execute and fail, and leave a log event.
     """
     settings.PORTAL_USER_ACCOUNT_SETUP_STEPS = [
-        'portal.apps.onboarding.steps.test_steps.MockProcessingCompleteStep',
-        'portal.apps.onboarding.steps.test_steps.MockProcessingFailStep'
+        {
+            'step': 'portal.apps.onboarding.steps.test_steps.MockProcessingCompleteStep'
+        },
+        {
+            'step': 'portal.apps.onboarding.steps.test_steps.MockProcessingFailStep'
+        }
     ]
     with pytest.raises(StepExecuteException):
         prepare_setup_steps(authenticated_user)
@@ -235,8 +257,12 @@ def test_sequence_with_history(settings, authenticated_user):
     """
 
     settings.PORTAL_USER_ACCOUNT_SETUP_STEPS = [
-        'portal.apps.onboarding.steps.test_steps.MockProcessingCompleteStep',
-        'portal.apps.onboarding.steps.test_steps.MockProcessingFailStep'
+        {
+            'step': 'portal.apps.onboarding.steps.test_steps.MockProcessingCompleteStep'
+        },
+        {
+            'step': 'portal.apps.onboarding.steps.test_steps.MockProcessingFailStep'
+        }
     ]
 
     # Artificially fail MockProcessingCompleteStep

--- a/server/portal/apps/onboarding/steps/abstract.py
+++ b/server/portal/apps/onboarding/steps/abstract.py
@@ -19,7 +19,7 @@ class AbstractStep:
         self.last_event = None
         self.events = []
         self.settings = next(
-            (step['settings'] for step in settings.PORTAL_USER_ACCOUNT_SETUP_STEPS if 
+            (step['settings'] for step in settings.PORTAL_USER_ACCOUNT_SETUP_STEPS if
                 step['step'] == self.step_name()),
             None
         )

--- a/server/portal/apps/onboarding/steps/abstract.py
+++ b/server/portal/apps/onboarding/steps/abstract.py
@@ -18,11 +18,15 @@ class AbstractStep:
         self.user = user
         self.last_event = None
         self.events = []
-        self.settings = next(
-            (step['settings'] for step in settings.PORTAL_USER_ACCOUNT_SETUP_STEPS if
-                step['step'] == self.step_name()),
-            None
-        )
+
+        try:
+            steps = settings.PORTAL_USER_ACCOUNT_SETUP_STEPS
+            step_dict = next(
+                step for step in steps if step['step'] == self.step_name()
+            )
+            self.settings = step_dict['settings']
+        except Exception:
+            self.settings = None
 
         try:
             # Restore event history

--- a/server/portal/apps/onboarding/steps/abstract.py
+++ b/server/portal/apps/onboarding/steps/abstract.py
@@ -3,6 +3,7 @@ from six import add_metaclass
 from portal.apps.onboarding.models import SetupEvent
 from portal.apps.onboarding.state import SetupState
 from django.urls import reverse
+from django.conf import settings
 
 
 @add_metaclass(ABCMeta)
@@ -17,6 +18,11 @@ class AbstractStep:
         self.user = user
         self.last_event = None
         self.events = []
+        self.settings = next(
+            (step['settings'] for step in settings.PORTAL_USER_ACCOUNT_SETUP_STEPS if 
+                step['step'] == self.step_name()),
+            None
+        )
 
         try:
             # Restore event history

--- a/server/portal/apps/onboarding/steps/abstract_unit_test.py
+++ b/server/portal/apps/onboarding/steps/abstract_unit_test.py
@@ -70,3 +70,19 @@ def test_str(mock_step):
 
 def test_settings(mock_step):
     assert mock_step.settings == {'key': 'value'}
+
+
+def test_step_missing(regular_user, settings):
+    settings.PORTAL_USER_ACCOUNT_SETUP_STEPS = []
+    mock_step = MockStep(regular_user)
+    assert mock_step.settings is None
+
+
+def test_step_setting_missing(regular_user, settings):
+    settings.PORTAL_USER_ACCOUNT_SETUP_STEPS = [
+        {
+            'step': 'portal.apps.onboarding.steps.test_steps.MockStep',
+        }
+    ]
+    mock_step = MockStep(regular_user)
+    assert mock_step.settings is None

--- a/server/portal/apps/onboarding/steps/abstract_unit_test.py
+++ b/server/portal/apps/onboarding/steps/abstract_unit_test.py
@@ -1,100 +1,72 @@
-from django.test import TestCase, RequestFactory, override_settings
 from portal.apps.onboarding.models import SetupEvent
 from portal.apps.onboarding.state import SetupState
 from django.db.models import signals
-from django.contrib.auth import get_user_model
 from portal.apps.onboarding.steps.test_steps import MockStep
 import pytest
 
 
-@pytest.mark.django_db(transaction=True)
-class TestAbstractStep(TestCase):
-    def setUp(self):
-        super(TestAbstractStep, self).setUp()
-        signals.post_save.disconnect(sender=SetupEvent, dispatch_uid="setup_event")
+@pytest.fixture(autouse=True)
+def disconnect_signal():
+    yield signals.post_save.disconnect(sender=SetupEvent, dispatch_uid="setup_event")
 
-        # Create a test user
-        User = get_user_model()
-        self.user = User.objects.create_user('test', 'test@test.com', 'test')
 
-        # Clear all prior SetupEvent objects in test db
-        SetupEvent.objects.all().delete()
+@pytest.fixture
+def mock_step(regular_user, django_db_reset_sequences):
+    yield MockStep(regular_user)
 
-    def tearDown(self):
-        super(TestAbstractStep, self).tearDown()
 
-    def test_init_no_event(self):
-        mock_step = MockStep(self.user)
-        self.assertIsNone(mock_step.last_event)
-        self.assertEqual(len(mock_step.events), 0)
+def test_init_not_event(mock_step):
+    assert mock_step.last_event is None
+    assert len(mock_step.events) == 0
 
-    def test_step_name(self):
-        mock_step = MockStep(self.user)
-        self.assertEqual(
-            mock_step.step_name(),
-            "portal.apps.onboarding.steps.test_steps.MockStep"
-        )
 
-    def test_webhook_url(self):
-        request = RequestFactory().get("/api/test")
-        mock_step = MockStep(self.user)
-        self.assertEqual(
-            mock_step.webhook_url(request),
-            "http://testserver/webhooks/onboarding/"
-        )
+def test_step_name(mock_step):
+    assert mock_step.step_name() == "portal.apps.onboarding.steps.test_steps.MockStep"
 
-    def test_log(self):
-        mock_step = MockStep(self.user)
-        mock_step.state = SetupState.PENDING
-        mock_step.log("test event")
-        events = SetupEvent.objects.all().filter(user=self.user)
-        self.assertEqual(events[0].message, "test event")
-        self.assertEqual(events[0].state, SetupState.PENDING)
 
-    def test_init_with_event(self):
-        mock_step = MockStep(self.user)
-        mock_step.state = SetupState.PENDING
-        mock_step.log("event 1")
-        mock_step.state = SetupState.COMPLETED
-        mock_step.log("event 2")
-        mock_step = MockStep(self.user)
-        self.assertEqual(mock_step.last_event.state, SetupState.COMPLETED)
-        self.assertEqual(len(mock_step.events), 2)
+def test_webhook_url(mock_step, rf):
+    request = rf.get("/api/test")
+    assert mock_step.webhook_url(request) == "http://testserver/webhooks/onboarding/"
 
-    def test_complete(self):
-        mock_step = MockStep(self.user)
-        mock_step.complete("Completed")
-        self.assertEqual(mock_step.state, SetupState.COMPLETED)
-        self.assertEqual(mock_step.last_event.state, SetupState.COMPLETED)
-        self.assertEqual(
-            SetupEvent.objects.all()[0].message,
-            "Completed"
-        )
 
-    def test_fail(self):
-        mock_step = MockStep(self.user)
-        mock_step.fail("Failure")
-        self.assertEqual(mock_step.state, SetupState.FAILED)
-        self.assertEqual(mock_step.last_event.state, SetupState.FAILED)
-        self.assertEqual(
-            SetupEvent.objects.all()[0].message,
-            "Failure"
-        )
+def test_log(mock_step, regular_user):
+    mock_step.state = SetupState.PENDING
+    mock_step.log("test event")
+    events = SetupEvent.objects.all().filter(user=regular_user)
+    assert events[0].message == "test event"
+    assert events[0].state == SetupState.PENDING
 
-    def test_str(self):
-        mock_step = MockStep(self.user)
-        mock_step.state = SetupState.PENDING
-        self.assertEqual(
-            str(mock_step),
-            "<portal.apps.onboarding.steps.test_steps.MockStep for test is pending>"
-        )
 
-    def test_settings(self):
-        mock_step = MockStep(self.user)
-        self.assertEqual(
-            mock_step.settings,
-            {
-                'key': 'value'
-            }
-        )
+def test_init_with_event(mock_step, regular_user):
+    mock_step.state = SetupState.PENDING
+    mock_step.log("event 1")
+    mock_step.state = SetupState.COMPLETED
+    mock_step.log("event 2")
 
+    # Re-initialize the step to load last event
+    mock_step = MockStep(regular_user)
+    assert mock_step.last_event.state == SetupState.COMPLETED
+    assert len(mock_step.events) == 2
+
+
+def test_complete(mock_step):
+    mock_step.complete("Completed")
+    assert mock_step.state == SetupState.COMPLETED
+    assert mock_step.last_event.state == SetupState.COMPLETED
+    assert SetupEvent.objects.all()[0].message == "Completed"
+
+
+def test_fail(mock_step):
+    mock_step.fail("Failure")
+    assert mock_step.state == SetupState.FAILED
+    assert mock_step.last_event.state == SetupState.FAILED
+    assert SetupEvent.objects.all()[0].message == "Failure"
+
+
+def test_str(mock_step):
+    mock_step.state = SetupState.PENDING
+    assert str(mock_step) == "<portal.apps.onboarding.steps.test_steps.MockStep for username is pending>"
+
+
+def test_settings(mock_step):
+    assert mock_step.settings == {'key': 'value'}

--- a/server/portal/apps/onboarding/steps/abstract_unit_test.py
+++ b/server/portal/apps/onboarding/steps/abstract_unit_test.py
@@ -1,4 +1,4 @@
-from django.test import TestCase, RequestFactory
+from django.test import TestCase, RequestFactory, override_settings
 from portal.apps.onboarding.models import SetupEvent
 from portal.apps.onboarding.state import SetupState
 from django.db.models import signals
@@ -88,3 +88,13 @@ class TestAbstractStep(TestCase):
             str(mock_step),
             "<portal.apps.onboarding.steps.test_steps.MockStep for test is pending>"
         )
+
+    def test_settings(self):
+        mock_step = MockStep(self.user)
+        self.assertEqual(
+            mock_step.settings,
+            {
+                'key': 'value'
+            }
+        )
+

--- a/server/portal/settings/settings.py
+++ b/server/portal/settings/settings.py
@@ -737,8 +737,25 @@ PORTAL_USER_HOME_MANAGER = settings_secret.\
 PORTAL_KEYS_MANAGER = settings_secret.\
     _PORTAL_KEYS_MANAGER
 
-PORTAL_USER_ACCOUNT_SETUP_STEPS = settings_secret.\
-    _PORTAL_USER_ACCOUNT_SETUP_STEPS
+"""
+Onboarding steps
+
+Each step is an object, with the full package name of the step class and
+an associated settings object. If the 'settings' key is omitted, steps will
+have a default value of None for their settings attribute.
+
+Example: 
+
+PORTAL_USER_ACCOUNT_SETUP_STEPS = [
+    {
+        'step': 'portal.apps.onboarding.steps.test_steps.MockStep',
+        'settings': {
+            'key': 'value'
+        }
+    }
+]
+"""
+PORTAL_USER_ACCOUNT_SETUP_STEPS = []
 
 PORTAL_USER_ACCOUNT_SETUP_WEBHOOK_PWD = settings_secret.\
     _PORTAL_USER_ACCOUNT_SETUP_WEBHOOK_PWD

--- a/server/portal/settings/settings_secret.example.py
+++ b/server/portal/settings/settings_secret.example.py
@@ -131,7 +131,6 @@ _PORTAL_DATA_DEPOT_USER_SYSTEM_PREFIX = 'cep.dev.home.{}'
 _PORTAL_DATA_DEPOT_STORAGE_HOST = 'data.tacc.utexas.edu'
 _PORTAL_USER_HOME_MANAGER = 'portal.apps.accounts.managers.user_home.UserHomeManager'
 _PORTAL_KEYS_MANAGER = 'portal.apps.accounts.managers.ssh_keys.KeysManager'
-_PORTAL_USER_ACCOUNT_SETUP_STEPS = []
 _PORTAL_DATA_DEPOT_WORK_HOME_DIR_FS = '/work'
 _PORTAL_DATA_DEPOT_WORK_HOME_DIR_EXEC_SYSTEM = 'EXECUTION_SYSTEM'
 _PORTAL_JUPYTER_URL = "https://jupyter.tacc.cloud"

--- a/server/portal/settings/unit_test_settings.py
+++ b/server/portal/settings/unit_test_settings.py
@@ -280,7 +280,12 @@ PORTAL_PROJECTS_PRIVATE_KEY = ('-----BEGIN RSA PRIVATE KEY-----'
 PORTAL_PROJECTS_PUBLIC_KEY = 'ssh-rsa change this'
 
 PORTAL_USER_ACCOUNT_SETUP_STEPS = [
-    'portal.apps.onboarding.steps.test_steps.MockStep'
+    {
+        'step': 'portal.apps.onboarding.steps.test_steps.MockStep',
+        'settings': {
+            'key': 'value'
+        }
+    }
 ]
 PORTAL_USER_ACCOUNT_SETUP_WEBHOOK_PWD = 'dev'
 

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -2,7 +2,7 @@ Django==2.2.7
 PyJWT==1.7.1
 agavepy==0.9.3
 cached-property==1.5.1
-celery==4.3.0
+celery==4.4.7
 certifi==2019.9.11
 channels==2.4.0
 channels-redis==2.4.1


### PR DESCRIPTION
## Overview: ##

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [FP-500](https://jira.tacc.utexas.edu/browse/FP-500)
* [FP-669](https://jira.tacc.utexas.edu/browse/FP-669)

## Summary of Changes: ##

- PORTAL_USER_ACCOUNT_SETUP_STEPS is no longer in settings_secret, values should be explicit in settings.py
- PORTAL_USER_ACCOUNT_SETUP_STEPS format has changed from list of strings to list of dicts: 

```
{
   'step': 'step.package.file_name.ClassName', 
   'settings': { 'key': 'value' }
}
```

- Settings are now automatically loaded and can be accessed from within step processing code using the `settings` attribute, rather than loading a specific key from django.conf settings. This should reduce proliferation of settings unique to each step.
- abstract_unit_test.py refactored to pytest

## Testing Steps: ##
1. Unit tests only

