### PR TITLE
task/FP-702 - onboarding -- refactor for cepv2

### DIFF
--- a/server/conf/nginx/nginx.conf
+++ b/server/conf/nginx/nginx.conf
@@ -80,7 +80,7 @@ http {
             alias /srv/www/portal/server/docs;
         }
 
-        location ~ ^/(core|auth|workbench|tickets|accounts|api|login|webhooks) {
+        location ~ ^/(core|auth|workbench|tickets|accounts|api|login|webhooks|onboarding) {
             proxy_pass http://portal_core;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header Host $host;

--- a/server/portal/apps/accounts/managers/unit_test.py
+++ b/server/portal/apps/accounts/managers/unit_test.py
@@ -136,19 +136,3 @@ class TestUserSetup(TestCase):
         setup("username", "system")
         self.mock_systems_manager.return_value.get_private_directory.assert_called_with(self.mock_user)
         self.mock_systems_manager.return_value.setup_private_system.assert_called_with(self.mock_user)
-
-    @skip("No onboarding steps are called right now")
-    @override_settings(PORTAL_USER_ACCOUNT_SETUP_STEPS=['fake.setup.setup_class'])
-    def test_setup_user(self):
-        # A user with setup_complete == False should cause setup steps to run
-        self.mock_user.profile.setup_complete = False
-        setup("username", "system")
-        self.mock_execute.assert_called_with(ANY)
-
-    @skip("No onboarding steps are called right now")
-    @override_settings(PORTAL_USER_ACCOUNT_SETUP_STEPS=['fake.setup.setup_class'])
-    def test_skip_setup(self):
-        # A user that has setup_complete should not execute setup steps
-        self.mock_user.profile.setup_complete = True
-        setup("username", "system")
-        self.mock_execute.assert_not_called()

--- a/server/portal/apps/accounts/views.py
+++ b/server/portal/apps/accounts/views.py
@@ -25,8 +25,11 @@ from django.template.loader import render_to_string
 from pytas.http import TASClient
 
 from portal.apps.accounts import forms, integrations
-from portal.apps.accounts.models import (PortalProfile,
-                                         NotificationPreferences)
+from portal.apps.accounts.models import (
+    PortalProfile,
+    NotificationPreferences
+)
+
 
 # pylint: disable=invalid-name
 logger = logging.getLogger(__name__)

--- a/server/portal/apps/auth/unit_test.py
+++ b/server/portal/apps/auth/unit_test.py
@@ -10,9 +10,22 @@ from mock import Mock, patch, MagicMock, ANY
 from portal.apps.auth.backends import AgaveOAuthBackend
 from requests import Response
 from portal.apps.accounts.models import PortalProfile
+from portal.apps.auth.views import launch_setup_checks
 import pytest
 
 pytestmark = pytest.mark.django_db
+
+
+def test_launch_setup_checks(mocker, regular_user, settings):
+    mock_check = mocker.patch('portal.apps.auth.views.new_user_setup_check')
+    mock_execute = mocker.patch('portal.apps.auth.views.execute_setup_steps')
+    mock_index = mocker.patch('portal.apps.auth.views.index_allocations')
+    mock_get_systems = mocker.patch('portal.apps.auth.views.get_user_storage_systems')
+    mock_get_systems.return_value = []
+    regular_user.profile.setup_complete = False
+    launch_setup_checks(regular_user)
+    mock_execute.apply_async.assert_called_with(args=['username'])
+    mock_index.apply_async.assert_called_with(args=['username'])
 
 
 class TestAgaveOAuthBackend(TransactionTestCase):

--- a/server/portal/apps/onboarding/middleware.py
+++ b/server/portal/apps/onboarding/middleware.py
@@ -32,7 +32,7 @@ class SetupCompleteMiddleware(object):
             return HttpResponseRedirect(reverse('portal_accounts:logout'))
 
         # check to see if user setup has finished
-        if not portal_profile.setup_complete:
+        if not portal_profile.setup_complete and reverse('workbench:index') in request.path:
             return HttpResponseRedirect(reverse('portal_onboarding:holding'))
 
         response = self.get_response(request)

--- a/server/portal/apps/onboarding/templates/portal/apps/onboarding/admin.html
+++ b/server/portal/apps/onboarding/templates/portal/apps/onboarding/admin.html
@@ -2,5 +2,4 @@
 {% load sekizai_tags staticfiles %}
 {% block title %} Account Administration {% endblock %}
 {% block content %}
-<onboarding-admin-view></onboarding-admin-view>
 {% endblock %}

--- a/server/portal/apps/onboarding/templates/portal/apps/onboarding/setup.html
+++ b/server/portal/apps/onboarding/templates/portal/apps/onboarding/setup.html
@@ -11,5 +11,4 @@
         <a href="mailto:{{ email }}">{{ email }}</a>
     </div>
 </div>
-<onboarding-setup-view username="{{ username }}" show-admin="true"></onboarding-setup-view>
 {% endblock %}

--- a/server/portal/apps/tickets/unit_test.py
+++ b/server/portal/apps/tickets/unit_test.py
@@ -4,7 +4,24 @@ def test_tickets_get(client, authenticated_user):
     assert response.url == '/workbench/dashboard/'
 
 
-def test_ticket_create_authenticated(client, authenticated_user):
+def test_ticket_create_authenticated(client, regular_user):
+    """Users who are setup_complete may use workbench/dashboard routes
+    """
+    regular_user.profile.setup_complete = True
+    regular_user.profile.save()
+    client.force_login(regular_user)
     response = client.get('/tickets/new/')
     assert response.status_code == 302
     assert response.url == '/workbench/dashboard/tickets/create/'
+
+
+def test_ticket_create_authenticated_setup_incomplete(client, regular_user):
+    """Users who are not setup_complete should not be redirected
+    to the /workbench/dashboard route, because the setup_complete
+    middleware would redirect them to the onboarding view
+    """
+    regular_user.profile.setup_complete = False
+    regular_user.profile.save()
+    client.force_login(regular_user)
+    response = client.get('/tickets/new/')
+    assert response.status_code == 200

--- a/server/portal/apps/tickets/views.py
+++ b/server/portal/apps/tickets/views.py
@@ -11,7 +11,7 @@ def tickets(request):
 
 @ensure_csrf_cookie
 def ticket_create(request):
-    if request.user.is_authenticated:
+    if request.user.is_authenticated and request.user.profile.setup_complete:
         response = redirect('/workbench/dashboard/tickets/create/')
         return response
     return render(request, 'portal/apps/workbench/index.html')

--- a/server/portal/settings/settings.py
+++ b/server/portal/settings/settings.py
@@ -143,7 +143,7 @@ MIDDLEWARE = [
     'cms.middleware.utils.ApphookReloadMiddleware',
 
     # Onboarding
-    # 'portal.apps.onboarding.middleware.SetupCompleteMiddleware'
+    'portal.apps.onboarding.middleware.SetupCompleteMiddleware'
 ]
 
 TEMPLATES = [


### PR DESCRIPTION
## Overview: ##

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [FP-702](https://jira.tacc.utexas.edu/browse/FP-702)
* [FP-669](https://jira.tacc.utexas.edu/browse/FP-669)

## Summary of Changes: ##

- The onboarding check is now enabled and performed during the agave auth callback, before Allocations are cached and additional private systems such as Longhorn are created.
- PORTAL_USER_ACCOUNT_SETUP_STEPS has not been refactored yet, and still exists in settings_secret.py. This is addressed in a different PR.
- Ticket creation routing for /tickets/new/ has had the logic altered. Users who have not completed onboarding (and had setup_complete = True) will not be redirected to the workbench when trying to access /tickets/new/. Users who are not setup_complete will not be allowed access to the dashboard
- The onboarding route is now enabled in nginx.conf for local docker dev (this will require a Camino level change in the conf later.)

## Testing Steps: ##

See [Confluence](https://confluence.tacc.utexas.edu/pages/viewpage.action?pageId=197591062)

## UI Photos:

## Notes: ##
