### PR TITLE
FP-760 Show time according to client's time zone

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -41,7 +41,7 @@
     "lint:js": "eslint .",
     "lint:css": "stylelint '**/*.{css,scss,sass}'",
     "build": "NODE_ENV=production BABEL_ENV=production webpack -p --display-error-details --config webpack.prod.js",
-    "test": "jest",
+    "test": "TZ=UTC-6 jest",
     "test:watch": "npm run test -- --watch",
     "staging": "NODE_ENV=development webpack --config webpack.dev.js",
     "dev": "NODE_ENV=development BABEL_ENV=development webpack-dev-server --config webpack.dev.js"

--- a/client/package.json
+++ b/client/package.json
@@ -41,7 +41,7 @@
     "lint:js": "eslint .",
     "lint:css": "stylelint '**/*.{css,scss,sass}'",
     "build": "NODE_ENV=production BABEL_ENV=production webpack -p --display-error-details --config webpack.prod.js",
-    "test": "TZ=UTC-6 jest",
+    "test": "TZ=America/Chicago jest",
     "test:watch": "npm run test -- --watch",
     "staging": "NODE_ENV=development webpack --config webpack.dev.js",
     "dev": "NODE_ENV=development BABEL_ENV=development webpack-dev-server --config webpack.dev.js"

--- a/client/src/utils/timeFormat.js
+++ b/client/src/utils/timeFormat.js
@@ -2,8 +2,7 @@ export function formatDate(timeDateValue) {
   return timeDateValue.toLocaleDateString('en-US', {
     day: '2-digit',
     month: '2-digit',
-    year: 'numeric',
-    timeZone: 'America/Chicago'
+    year: 'numeric'
   });
 }
 
@@ -11,8 +10,7 @@ export function formatTime(timeDateValue) {
   return timeDateValue.toLocaleTimeString('en-US', {
     hour12: false,
     hour: '2-digit',
-    minute: '2-digit',
-    timeZone: 'America/Chicago'
+    minute: '2-digit'
   });
 }
 

--- a/client/src/utils/timeFormat.test.js
+++ b/client/src/utils/timeFormat.test.js
@@ -1,0 +1,8 @@
+import { formatDateTime } from './timeFormat';
+
+
+describe('time utility functions', () => {
+  it('get formatted times', () => {
+    expect(formatDateTime(new Date("2020-10-15T17:01:14.447Z"))).toEqual('10/15/2020 12:01');
+  });
+});


### PR DESCRIPTION
## Overview: ##
Fix for displaying job times using the client's time zone and not assuming CST.

## PR Status: ##

* [X] Ready.


## Related Jira tickets: ##

* [FP-760](https://jira.tacc.utexas.edu/browse/FP-760)

## Summary of Changes: ##
* Fix for displaying job times using the client's time zone and not assuming CST.
* Add unit test
## Testing Steps: ##
1. Run unit tests
2. When this is merged, we should test dev again (with our time zone set to non-central zone)

## Notes: ##
Here, I set the time zone to be CST for our tests. This is done in the `client/package.json`:  _"test": "TZ=America/Chicago jest"_  An alternative would be to set the time zone in the the jest global-setup.js as outlined here:  https://stackoverflow.com/questions/56261381/how-do-i-set-a-timezone-in-my-jest-config?answertab=votes#tab-top