### PR TITLE
task/FP-597 - Swap Alert component to Message component in applications

### DIFF
--- a/client/src/components/Applications/AppForm/AppForm.js
+++ b/client/src/components/Applications/AppForm/AppForm.js
@@ -2,7 +2,13 @@ import React from 'react';
 import { Button, FormGroup } from 'reactstrap';
 import { useSelector, useDispatch, shallowEqual } from 'react-redux';
 import { Formik, Form } from 'formik';
-import { AppIcon, FormField, Icon, LoadingSpinner, Message } from '_common';
+import {
+  AppIcon,
+  FormField,
+  Icon,
+  LoadingSpinner,
+  SectionMessage
+} from '_common';
 import * as Yup from 'yup';
 import parse from 'html-react-parser';
 import './AppForm.scss';
@@ -66,9 +72,9 @@ const AppDetail = () => {
     const errorText = error.message ? error.message : 'Something went wrong.';
 
     return (
-      <Message type="warn" className="appDetail-error">
+      <SectionMessage type="warning" className="appDetail-error">
         {errorText}
-      </Message>
+      </SectionMessage>
     );
   }
 
@@ -197,7 +203,7 @@ export const AppSchemaForm = ({ app }) => {
       {jobSubmission.response && (
         <div id="appForm-alerts">
           {jobSubmission.error ? (
-            <Message type="warn" className="appDetail-error">
+            <SectionMessage type="warning" className="appDetail-error">
               Error: {jobSubmission.response.message}
               {missingAllocation && (
                 <>
@@ -208,9 +214,9 @@ export const AppSchemaForm = ({ app }) => {
                   &nbsp;to request access.
                 </>
               )}
-            </Message>
+            </SectionMessage>
           ) : (
-            <Message type="info" className="appDetail-error">
+            <SectionMessage type="info" className="appDetail-error">
               Your job has submitted successfully. See details in{' '}
               <Link
                 to={`${ROUTES.WORKBENCH}${ROUTES.HISTORY}/jobs`}
@@ -219,7 +225,7 @@ export const AppSchemaForm = ({ app }) => {
                 History &gt; Jobs
               </Link>
               .
-            </Message>
+            </SectionMessage>
           )}
         </div>
       )}

--- a/client/src/components/Applications/AppForm/AppForm.js
+++ b/client/src/components/Applications/AppForm/AppForm.js
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { Button, FormGroup, Alert } from 'reactstrap';
+import React from 'react';
+import { Button, FormGroup } from 'reactstrap';
 import { useSelector, useDispatch, shallowEqual } from 'react-redux';
 import { Formik, Form } from 'formik';
 import { AppIcon, FormField, Icon, LoadingSpinner, Message } from '_common';
@@ -192,16 +192,12 @@ export const AppSchemaForm = ({ app }) => {
     initialValues.allocation = app.scheduler;
   }
 
-  // local state for alerts
-  const [visible, setVisible] = useState(true);
-  const onDismiss = () => setVisible(false);
-
   return (
     <div id="appForm-wrapper">
       {jobSubmission.response && (
         <div id="appForm-alerts">
           {jobSubmission.error ? (
-            <Alert color="warning" isOpen={visible} toggle={onDismiss}>
+            <Message type="warn" className="appDetail-error">
               Error: {jobSubmission.response.message}
               {missingAllocation && (
                 <>
@@ -212,9 +208,9 @@ export const AppSchemaForm = ({ app }) => {
                   &nbsp;to request access.
                 </>
               )}
-            </Alert>
+            </Message>
           ) : (
-            <Alert color="info" isOpen={visible} toggle={onDismiss}>
+            <Message type="info" className="appDetail-error">
               Your job has submitted successfully. See details in{' '}
               <Link
                 to={`${ROUTES.WORKBENCH}${ROUTES.HISTORY}/jobs`}
@@ -223,7 +219,7 @@ export const AppSchemaForm = ({ app }) => {
                 History &gt; Jobs
               </Link>
               .
-            </Alert>
+            </Message>
           )}
         </div>
       )}

--- a/client/src/components/Applications/AppForm/AppForm.js
+++ b/client/src/components/Applications/AppForm/AppForm.js
@@ -72,9 +72,9 @@ const AppDetail = () => {
     const errorText = error.message ? error.message : 'Something went wrong.';
 
     return (
-      <SectionMessage type="warning" className="appDetail-error">
-        {errorText}
-      </SectionMessage>
+      <div className="appDetail-error">
+        <SectionMessage type="warning">{errorText}</SectionMessage>
+      </div>
     );
   }
 
@@ -203,29 +203,36 @@ export const AppSchemaForm = ({ app }) => {
       {jobSubmission.response && (
         <div id="appForm-alerts">
           {jobSubmission.error ? (
-            <SectionMessage type="warning" className="appDetail-error">
-              Error: {jobSubmission.response.message}
-              {missingAllocation && (
-                <>
-                  &nbsp;Please click&nbsp;
-                  <Link to="/workbench/allocations/manage" className="wb-link">
-                    here
-                  </Link>
-                  &nbsp;to request access.
-                </>
-              )}
-            </SectionMessage>
+            <div className="appDetail-error">
+              <SectionMessage type="warning">
+                Error: {jobSubmission.response.message}
+                {missingAllocation && (
+                  <>
+                    &nbsp;Please click&nbsp;
+                    <Link
+                      to="/workbench/allocations/manage"
+                      className="wb-link"
+                    >
+                      here
+                    </Link>
+                    &nbsp;to request access.
+                  </>
+                )}
+              </SectionMessage>
+            </div>
           ) : (
-            <SectionMessage type="info" className="appDetail-error">
-              Your job has submitted successfully. See details in{' '}
-              <Link
-                to={`${ROUTES.WORKBENCH}${ROUTES.HISTORY}/jobs`}
-                className="wb-link"
-              >
-                History &gt; Jobs
-              </Link>
-              .
-            </SectionMessage>
+            <div className="appDetail-error">
+              <SectionMessage type="info">
+                Your job has submitted successfully. See details in{' '}
+                <Link
+                  to={`${ROUTES.WORKBENCH}${ROUTES.HISTORY}/jobs`}
+                  className="wb-link"
+                >
+                  History &gt; Jobs
+                </Link>
+                .
+              </SectionMessage>
+            </div>
           )}
         </div>
       )}

--- a/client/src/components/Applications/AppForm/AppForm.js
+++ b/client/src/components/Applications/AppForm/AppForm.js
@@ -222,7 +222,7 @@ export const AppSchemaForm = ({ app }) => {
             </div>
           ) : (
             <div className="appDetail-error">
-              <SectionMessage type="info">
+              <SectionMessage type="success">
                 Your job has submitted successfully. See details in{' '}
                 <Link
                   to={`${ROUTES.WORKBENCH}${ROUTES.HISTORY}/jobs`}

--- a/client/src/components/Applications/AppForm/AppForm.scss
+++ b/client/src/components/Applications/AppForm/AppForm.scss
@@ -78,5 +78,5 @@
     justify-content: center;
     height: 100%; /* Be consistent with `#appDetail-wrapper`/`.app-placeholder` (which can exist at the same location),
                      so that `appBrowser-wrapper` height does not change based on sibling content */
-    padding: 30px;
+    padding: 30px 0;
 }


### PR DESCRIPTION
## Overview: ##
Swapped out "Alert" component to "Message" component in the Applications area. I noticed the old alert message was dismissible with an X button, and the new messages will not be. Hopefully that is the intended behavior. 

## PR Status: ##

* [x] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [FP-597](https://jira.tacc.utexas.edu/browse/FP-597)

## Summary of Changes: ##

## Testing Steps: ##
1. Head to the applications page and create a job on a system where you have an allocation and one without. You should see either success/error messages.

## UI Photos:
<img width="983" alt="Screen Shot 2020-12-17 at 4 23 20 PM" src="https://user-images.githubusercontent.com/29575979/102550979-6936ec80-4084-11eb-991b-d777a18cbeb7.png">
