### PR TITLE
Task/FP-659 - Change default blue links in license modal to purple

### DIFF
--- a/client/src/components/ManageAccount/ManageAccountTables.js
+++ b/client/src/components/ManageAccount/ManageAccountTables.js
@@ -132,6 +132,7 @@ const LicenseCell = ({ cell: { value } }) => {
           <div dangerouslySetInnerHTML={{ __html }} />
           Click{' '}
           <Link
+            class="btn-link"
             to={`/workbench/dashboard/tickets/create?subject=${type}+Activation`}
           >
             here

--- a/server/portal/apps/licenses/templates/portal/apps/licenses/matlab_details.html
+++ b/server/portal/apps/licenses/templates/portal/apps/licenses/matlab_details.html
@@ -1,5 +1,5 @@
 <p>
-    <a href="http://www.mathworks.com/" target="_blank">Mathworks' MATLAB <i class="fas fa-external-link-alt"></i></a>
+    <a class="btn-link" href="http://www.mathworks.com/" target="_blank">Mathworks' MATLAB <i class="fas fa-external-link-alt"></i></a>
     is available to Academic users in the Portal Applications Workspace but requires activation.
 </p>
 <p>


### PR DESCRIPTION
## Overview: ##
Change default blue <a> tag links in the license modal template to purple.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [FP-659](https://jira.tacc.utexas.edu/browse/FP-659)

## Summary of Changes: ##

## Testing Steps: ##
1. Navigate to your user account page and click the "Request Activation" link next to MATLAB on the right
2. Check that both of the links in the modal are now purple instead of blue

## UI Photos:
![links](https://user-images.githubusercontent.com/29575979/97357254-7810d800-1867-11eb-810b-19413676b777.png)


## Notes: ##
