### PR TITLE
Task/FP-768: add disabled property to sidebar

### DIFF
--- a/client/src/components/History/HistoryBadge/HistoryBadge.js
+++ b/client/src/components/History/HistoryBadge/HistoryBadge.js
@@ -1,11 +1,12 @@
 import React from 'react';
-import { number } from 'prop-types';
+import PropTypes, { number } from 'prop-types';
 import './HistoryBadge.module.scss';
 
-const HistoryBadge = ({ unread }) => {
+const HistoryBadge = ({ unread, disabled }) => {
+  const rootStyle = disabled ? 'root disabled' : 'root';
   if (unread) {
     return (
-      <span styleName="root" role="status">
+      <span styleName={rootStyle} role="status">
         {unread < 1000 ? unread : '999+'}
       </span>
     );
@@ -13,7 +14,12 @@ const HistoryBadge = ({ unread }) => {
   return <></>;
 };
 HistoryBadge.propTypes = {
-  unread: number.isRequired
+  unread: number.isRequired,
+  disabled: PropTypes.bool
+};
+
+HistoryBadge.defaultProps = {
+  disabled: false
 };
 
 export default HistoryBadge;

--- a/client/src/components/History/HistoryBadge/HistoryBadge.module.scss
+++ b/client/src/components/History/HistoryBadge/HistoryBadge.module.scss
@@ -4,8 +4,12 @@
     text-align: center;
     font-size: 0.75em;  /* ~10px design * 1.2 design-to-app ratio */
     border-radius: 3.6px;
-    background-color: #9d85ef;
+    background-color: var(--global-color-accent--normal);
     color: rgb(253, 241, 241);
     margin-left: auto;
     margin-right: 2em;
+}
+
+.disabled {
+    background-color: var(--global-color-accent--light);
 }

--- a/client/src/components/Onboarding/Onboarding.js
+++ b/client/src/components/Onboarding/Onboarding.js
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import { Route, Switch, Redirect, useRouteMatch } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 import { BrowserChecker } from '_common';
+import Sidebar from '../Sidebar';
 import OnboardingAdmin from './OnboardingAdmin';
 import OnboardingUser from './OnboardingUser';
 
@@ -15,13 +16,16 @@ function Onboarding() {
   }, []);
 
   return (
-    <div>
+    <div className="workbench-wrapper">
       <BrowserChecker />
-      <Switch>
-        <Route path={`${path}/setup/:username?`} component={OnboardingUser} />
-        <Route path={`${path}/admin`} component={OnboardingAdmin} />
-        <Redirect from={`${path}`} to={`${path}/setup`} />
-      </Switch>
+      <Sidebar disabled />
+      <div className="workbench-content">
+        <Switch>
+          <Route path={`${path}/setup/:username?`} component={OnboardingUser} />
+          <Route path={`${path}/admin`} component={OnboardingAdmin} />
+          <Redirect from={`${path}`} to={`${path}/setup`} />
+        </Switch>
+      </div>
     </div>
   );
 }

--- a/client/src/components/Sidebar/Sidebar.js
+++ b/client/src/components/Sidebar/Sidebar.js
@@ -91,7 +91,7 @@ const Sidebar = ({ disabled }) => {
         iconName="history"
         disabled={disabled}
       >
-        <HistoryBadge unread={unread} />
+        <HistoryBadge unread={unread} disabled={disabled} />
       </SidebarItem>
       {showUIPatterns && (
         <SidebarItem

--- a/client/src/components/Sidebar/Sidebar.js
+++ b/client/src/components/Sidebar/Sidebar.js
@@ -2,13 +2,53 @@ import React from 'react';
 import { Nav, NavItem, NavLink } from 'reactstrap';
 import { NavLink as RRNavLink, useRouteMatch } from 'react-router-dom';
 import { useSelector } from 'react-redux';
+import PropTypes from 'prop-types';
+import { Icon } from '_common';
 import * as ROUTES from '../../constants/routes';
 import HistoryBadge from '../History/HistoryBadge';
 import './Sidebar.global.scss'; // XXX: Global stylesheet imported in component
 import './Sidebar.module.scss';
 
+/** Navigation list item **/
+const SidebarItem = ({ to, label, iconName, children, disabled }) => {
+  return (
+    <NavItem>
+      <NavLink
+        tag={RRNavLink}
+        exact
+        to={to}
+        styleName="link"
+        activeStyleName="link--active"
+        disabled={disabled}
+      >
+        <div
+          styleName={disabled ? 'content disabled' : 'content'}
+          className="nav-content"
+        >
+          <Icon name={iconName} />
+          <span styleName="text">{label}</span>
+          {children}
+        </div>
+      </NavLink>
+    </NavItem>
+  );
+};
+
+SidebarItem.propTypes = {
+  to: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  iconName: PropTypes.string.isRequired,
+  children: PropTypes.node,
+  disabled: PropTypes.bool
+};
+
+SidebarItem.defaultProps = {
+  children: null,
+  disabled: false
+};
+
 /** A navigation list for the application */
-const Sidebar = () => {
+const Sidebar = ({ disabled }) => {
   // Show some entries only in local development
   const isDebug = useSelector(state =>
     state.workbench.status ? state.workbench.status.debug : false
@@ -21,90 +61,56 @@ const Sidebar = () => {
 
   return (
     <Nav styleName="root" vertical>
-      <NavItem>
-        <NavLink
-          tag={RRNavLink}
-          exact
-          to={`${path}${ROUTES.DASHBOARD}`}
-          styleName="link"
-          activeStyleName="link--active"
-        >
-          <div styleName="content" className="nav-content">
-            <i className="icon icon-dashboard" />
-            <span styleName="text">Dashboard</span>
-          </div>
-        </NavLink>
-      </NavItem>
-      <NavItem>
-        <NavLink
-          tag={RRNavLink}
-          to={`${path}${ROUTES.DATA}`}
-          styleName="link"
-          activeStyleName="link--active"
-        >
-          <div styleName="content" className="nav-content">
-            <i className="icon icon-folder" />
-            <span styleName="text">Data Files</span>
-          </div>
-        </NavLink>
-      </NavItem>
-      <NavItem>
-        <NavLink
-          tag={RRNavLink}
-          to={`${path}${ROUTES.APPLICATIONS}`}
-          styleName="link"
-          activeStyleName="link--active"
-        >
-          <div styleName="content" className="nav-content">
-            <i className="icon icon-applications" />
-            <span styleName="text">Applications</span>
-          </div>
-        </NavLink>
-      </NavItem>
-      <NavItem>
-        <NavLink
-          tag={RRNavLink}
-          to={`${path}${ROUTES.ALLOCATIONS}`}
-          styleName="link"
-          activeStyleName="link--active"
-        >
-          <div styleName="content" className="nav-content">
-            <i className="icon icon-allocations" />
-            <span styleName="text">Allocations</span>
-          </div>
-        </NavLink>
-      </NavItem>
-      <NavItem>
-        <NavLink
-          tag={RRNavLink}
-          to={`${path}${ROUTES.HISTORY}`}
-          styleName="link"
-          activeStyleName="link--active"
-        >
-          <div styleName="content" className="nav-content">
-            <i className="icon icon-history" />
-            <span styleName="text">History</span>
-            <HistoryBadge unread={unread} />
-          </div>
-        </NavLink>
-      </NavItem>
+      <SidebarItem
+        to={`${path}${ROUTES.DASHBOARD}`}
+        label="Dashboard"
+        iconName="dashboard"
+        disabled={disabled}
+      />
+      <SidebarItem
+        to={`${path}${ROUTES.DATA}`}
+        label="Data Files"
+        iconName="folder"
+        disabled={disabled}
+      />
+      <SidebarItem
+        to={`${path}${ROUTES.APPLICATIONS}`}
+        label="Applications"
+        iconName="applications"
+        disabled={disabled}
+      />
+      <SidebarItem
+        to={`${path}${ROUTES.ALLOCATIONS}`}
+        label="Allocations"
+        iconName="allocations"
+        disabled={disabled}
+      />
+      <SidebarItem
+        to={`${path}${ROUTES.HISTORY}`}
+        label="History"
+        iconName="history"
+        disabled={disabled}
+      >
+        <HistoryBadge unread={unread} />
+      </SidebarItem>
       {showUIPatterns && (
-        <NavItem>
-          <NavLink
-            tag={RRNavLink}
-            to={`${path}${ROUTES.UI}`}
-            styleName="link"
-            activeStyleName="link--active"
-          >
-            <div styleName="content" className="nav-content">
-              <i className="icon icon-copy" />
-              <span styleName="text">UI Patterns</span>
-            </div>
-          </NavLink>
-        </NavItem>
+        <SidebarItem
+          to={`${path}${ROUTES.UI}`}
+          label="UI Patterns"
+          iconName="copy"
+          disabled={disabled}
+        />
       )}
     </Nav>
   );
+};
+
+Sidebar.propTypes = {
+  disabled: PropTypes.bool
+};
+
+Sidebar.defaultProps = {
+  disabled: false
 };
 
 export default Sidebar;

--- a/client/src/components/Sidebar/Sidebar.module.scss
+++ b/client/src/components/Sidebar/Sidebar.module.scss
@@ -26,3 +26,7 @@ $width: 215px;
   font-size: 0.75em; /* ~20px (16px design * 1.2 design-to-app ratio) */
   font-weight: 500;
 }
+
+.disabled {
+  color: var(--global-color-primary--light);
+}

--- a/client/src/components/Sidebar/Sidebar.module.scss
+++ b/client/src/components/Sidebar/Sidebar.module.scss
@@ -30,3 +30,4 @@ $width: 215px;
 .disabled {
   color: var(--global-color-primary--light);
 }
+

--- a/client/src/components/Sidebar/Sidebar.module.scss
+++ b/client/src/components/Sidebar/Sidebar.module.scss
@@ -30,4 +30,3 @@ $width: 215px;
 .disabled {
   color: var(--global-color-primary--light);
 }
-


### PR DESCRIPTION
## Overview: ##

Update on-boarding ui to include disabled property to sidebar.  

## PR Status: ##

* [x] Ready.

## Related Jira tickets: ##

This is related to but will require follow on work:
* [FP-768](https://jira.tacc.utexas.edu/browse/FP-768)

## Summary of Changes: ##
* Make sidebar disabled-able
* Use sidebar in onboarding view

## Testing Steps: ##
1. View onboarding view and compare with UI mockups 

## UI Photos:
![Screen Shot 2020-11-02 at 10 23 36 AM](https://user-images.githubusercontent.com/8287580/97892370-8773a380-1cf5-11eb-9bd9-23961f1d584f.png)

## Notes: ##
This PR just adds a disabled sidebar to current onboarding path.  A second PR will be submitted where onboarding route (`/onboarding`) is moved under (`/workbench`)
