### PR TITLE
Task/fp 764 provisional onboardng  title h2 tweak

### DIFF
--- a/client/src/components/Onboarding/OnboardingUser.js
+++ b/client/src/components/Onboarding/OnboardingUser.js
@@ -44,13 +44,11 @@ const OnboardingUser = () => {
 
   return (
     <div styleName="root">
-      <div styleName="title">
-        <h2>
-          {isStaff
-            ? `Onboarding Administration for ${user.username} - ${user.lastName}, ${user.firstName}`
-            : 'The following steps must be completed before accessing the portal'}
-        </h2>
-      </div>
+      <h2 styleName="title">
+        {isStaff
+          ? `Onboarding Administration for ${user.username} - ${user.lastName}, ${user.firstName}`
+          : 'The following steps must be completed before accessing the portal'}
+      </h2>
       <div styleName="container">
         {user.steps.map(step => (
           <OnboardingStep step={step} key={uuidv4()} />


### PR DESCRIPTION
## Overview: ##

Reduce excess markup, and illustrate what I intended with https://github.com/TACC/Frontera-Portal/pull/225#discussion_r516293475.

## PR Status: ##

* [X] Work in Progress.

## Related Jira tickets: ##

* [FP-764](https://jira.tacc.utexas.edu/browse/FP-764)

## Summary of Changes: ##

- Change `div.title > h2` to `h2.title`.

## Testing Steps: ##
1. Get environment setup for testing #225.
2. Test that heading style has not changed from `task/FP-764-provisional-onboarding`.

## UI Photos:

(pending author's ability to test; see [troubles](https://tacc-team.slack.com/archives/GQW4Q8HLG/p1604502401178000?thread_ts=1604501191.176800&cid=GQW4Q8HLG))

## Notes: ##

The [suggestion](https://github.com/TACC/Frontera-Portal/pull/225#discussion_r516293475) was clear, I think. But, [the change was __not__ to use `h2.title`](https://github.com/TACC/Frontera-Portal/commit/37a19e437088ba269a1d4add66d439bdd80d056d#diff-3f0f8a0b497262896083e4db33ad4f31eccf19bba8dfd6fdab727ea94092cc7d). So, I think there must have been a hiccup, and I'd like to see for myself what the hiccup was, and whether I can quickly solve it.