### PR TITLE
Quick: Reduce <Message> `warn`'s to `info`'s

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,9 @@ pip install -r server/requirements.txt
 
 Server-side python testing is run through pytest. Run `pytest -ra` from the `server` folder to run backend tests and display a report at the bottom of the output.
 
-Client-side javascript testing is run through Jest. Run `npm run test` from the `client` folder to ensure tests are running correctly.
+Client-side javascript testing is run through Jest. Run `npm run test`* from the `client` folder to ensure tests are running correctly.
+
+\* To run tests without console logging, run `npm run test -- --silent`.
 
 #### Test Coverage
 

--- a/client/src/components/_common/Message/Message.js
+++ b/client/src/components/_common/Message/Message.js
@@ -86,11 +86,11 @@ const Message = ({
   }
   if (type === 'warn') {
     // Component will work, but `warn` is deprecated value
-    console.warn(ERROR_TEXT.deprecatedType);
+    console.info(ERROR_TEXT.deprecatedType);
   }
   if (!scope) {
     // Component will work, but `scope` should be defined
-    console.warn(ERROR_TEXT.missingScope);
+    console.info(ERROR_TEXT.missingScope);
   }
   /* eslint-enable no-console */
 

--- a/client/src/components/_common/Message/Message.test.js
+++ b/client/src/components/_common/Message/Message.test.js
@@ -152,7 +152,7 @@ describe('Message', () => {
       );
     });
     test('is announced for `type="warn"`', () => {
-      console.warn = jest.fn();
+      console.info = jest.fn();
       render(
         <Message
           type="warn"
@@ -161,12 +161,12 @@ describe('Message', () => {
           {TEST_CONTENT}
         </Message>
       );
-      expect(console.warn).toHaveBeenCalledWith(
+      expect(console.info).toHaveBeenCalledWith(
         MSG.ERROR_TEXT.deprecatedType
       );
     });
     test('is announced for missing `scope` value', () => {
-      console.warn = jest.fn();
+      console.info = jest.fn();
       render(
         <Message
           type={TEST_TYPE}
@@ -174,7 +174,7 @@ describe('Message', () => {
           {TEST_CONTENT}
         </Message>
       );
-      expect(console.warn).toHaveBeenCalledWith(
+      expect(console.info).toHaveBeenCalledWith(
         MSG.ERROR_TEXT.missingScope
       );
     });


### PR DESCRIPTION
## Overview: ##

Make prior `<Message>` usage emit logging less loud than a `console.warn`.

## Related Jira tickets: ##

* [FP-639](https://jira.tacc.utexas.edu/browse/FP-639)

## Summary of Changes: ##

- _Minor_: Change two `console.warn`'s to `console.info`'s
- _Minor_: Update `README.md` with note about how to silence logging in tests.

## Testing Steps: ##
1. Run `npm run test`.
1. See **info** logging about `Message` usage.
1. Run `npm run test -- --silent`.
1. See **no** logging about `Message` usage.

## UI Photos:

__`npm run test`__
![npm run test](https://user-images.githubusercontent.com/62723358/100938396-3a344e80-34ba-11eb-9eeb-62c2784e5044.png)

__`npm run test -- --silent`__
![npm run test -- --silent](https://user-images.githubusercontent.com/62723358/100938391-39032180-34ba-11eb-88a8-eb351447d907.png)

## Notes: ##
