### PR TITLE
Task/FP-604 - Remove "close" buttons from modals with X button

### DIFF
--- a/client/src/components/DataFiles/DataFilesModals/DataFilesMkdirModal.js
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesMkdirModal.js
@@ -76,14 +76,7 @@ const DataFilesMkdirModal = () => {
             </ModalBody>
             <ModalFooter>
               <Button type="submit" className="data-files-btn">
-                Create Folder{' '}
-              </Button>
-              <Button
-                color="secondary"
-                className="data-files-btn-cancel"
-                onClick={toggle}
-              >
-                Close
+                Create Folder
               </Button>
             </ModalFooter>
           </Form>

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesPreviewModal.js
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesPreviewModal.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Button, Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
+import { Modal, ModalHeader, ModalBody } from 'reactstrap';
 import { LoadingSpinner } from '_common';
 
 const PreviewModalSpinner = () => (
@@ -66,15 +66,6 @@ const DataFilesPreviewModal = () => {
             </div>
           )}
         </ModalBody>
-        <ModalFooter>
-          <Button
-            color="secondary"
-            className="data-files-btn-cancel"
-            onClick={toggle}
-          >
-            Close
-          </Button>
-        </ModalFooter>
       </Modal>
     </>
   );

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesPushKeysModal.js
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesPushKeysModal.js
@@ -83,13 +83,6 @@ const DataFilesPushKeysModal = () => {
             <Button type="submit" color="primary" onClick={pushKeys}>
               Authenticate
             </Button>
-            <Button
-              color="secondary"
-              className="data-files-btn-cancel"
-              onClick={toggle}
-            >
-              Close
-            </Button>
           </ModalFooter>
         </Form>
       </Modal>

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesRenameModal.js
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesRenameModal.js
@@ -85,14 +85,7 @@ const DataFilesRenameModal = () => {
           </ModalBody>
           <ModalFooter>
             <Button type="submit" className="data-files-btn">
-              Rename{' '}
-            </Button>{' '}
-            <Button
-              color="secondary"
-              className="data-files-btn-cancel"
-              onClick={toggle}
-            >
-              Close
+              Rename
             </Button>
           </ModalFooter>
         </Form>

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesTrashModal.js
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesTrashModal.js
@@ -95,13 +95,6 @@ const DataFilesTrashModal = React.memo(() => {
         >
           Trash
         </Button>
-        <Button
-          color="secondary"
-          className="data-files-btn-cancel"
-          onClick={toggle}
-        >
-          Close
-        </Button>
       </ModalFooter>
     </Modal>
   );

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesUploadModal.js
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesUploadModal.js
@@ -174,13 +174,6 @@ const DataFilesUploadModal = () => {
       <ModalFooter>
         <Button className="data-files-btn" onClick={uploadStart}>
           Upload Selected
-        </Button>{' '}
-        <Button
-          color="secondary"
-          className="data-files-btn-cancel"
-          onClick={toggle}
-        >
-          Close
         </Button>
       </ModalFooter>
     </Modal>


### PR DESCRIPTION
## Overview: ##
Most of the updated modals handle file operations in the datafiles area. Craig reported that the modals which have an exit button on the top right should **not** have a "Close" button on the bottom.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [FP-604](https://jira.tacc.utexas.edu/browse/FP-604)

## Summary of Changes: ##
Removed close buttons from modals

## Testing Steps: ##
1. Open the modals; a "Close" button should not exist.
2. Within the Preview modal, the entire footer and button was removed.

## UI Photos:

## Notes: ##
