### PR TITLE
Quick/support tagname on message

### DIFF
--- a/client/src/components/_common/Message/Message.js
+++ b/client/src/components/_common/Message/Message.js
@@ -64,6 +64,7 @@ export const DEFAULT_SCOPE = 'inline'; // FAQ: Historical support for default
  */
 const Message = ({
   children,
+  tagName,
   className,
   onDismiss,
   canDismiss,
@@ -74,7 +75,7 @@ const Message = ({
   const typeMap = TYPE_MAP[type];
   const scopeMap = SCOPE_MAP[scope || DEFAULT_SCOPE];
   const { iconName, iconText, className: typeClassName } = typeMap;
-  const { role, tagName, className: scopeClassName } = scopeMap;
+  const { role, tagName: defaultTagName, className: scopeClassName } = scopeMap;
 
   const hasDismissSupport = scope === 'section';
 
@@ -116,7 +117,7 @@ const Message = ({
       // Avoid manually syncing Reactstrap <Fade>'s default props
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...fadeProps}
-      tag={tagName}
+      tag={tagName || defaultTagName}
       styleName={containerStyleNames}
       className={className}
       role={role}
@@ -155,6 +156,9 @@ Message.propTypes = {
   onDismiss: PropTypes.func,
   /** How to place the message within the layout */
   scope: PropTypes.oneOf(SCOPES), // RFE: Require scope; change all instances
+  /** A specific element tag to use for the root element */
+  /* HACK: Tag name should not be user-defined (because the default per scope is sematnic), but this allows reducing size of message text (by setting `small` tagName) (size reduction should be done consistently based on context, not whenever design chooses; but that context is not defined, yet) */
+  tagName: PropTypes.string,
   /** Message type or severity */
   type: PropTypes.oneOf(TYPES).isRequired
 };
@@ -163,7 +167,8 @@ Message.defaultProps = {
   canDismiss: false,
   isVisible: true,
   onDismiss: () => {},
-  scope: '' // RFE: Require scope; remove this line
+  scope: '', // RFE: Require scope; remove this line
+  tagName: ''
 };
 
 export default Message;

--- a/client/src/components/_common/Message/Message.js
+++ b/client/src/components/_common/Message/Message.js
@@ -75,7 +75,11 @@ const Message = ({
   const typeMap = TYPE_MAP[type];
   const scopeMap = SCOPE_MAP[scope || DEFAULT_SCOPE];
   const { iconName, iconText, className: typeClassName } = typeMap;
-  const { role, tagName: defaultTagName, className: scopeClassName } = scopeMap;
+  const {
+    role,
+    tagName: standardTagName,
+    className: scopeClassName
+  } = scopeMap;
 
   const hasDismissSupport = scope === 'section';
 
@@ -117,7 +121,7 @@ const Message = ({
       // Avoid manually syncing Reactstrap <Fade>'s default props
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...fadeProps}
-      tag={tagName || defaultTagName}
+      tag={tagName || standardTagName}
       styleName={containerStyleNames}
       className={className}
       role={role}

--- a/client/src/components/_common/Message/Message.module.scss
+++ b/client/src/components/_common/Message/Message.module.scss
@@ -45,8 +45,11 @@ p.is-scope-section {
 // }
 .type-icon {
   margin-right: 0.25em; /* ~4px */
-  margin-top: 0.125em; /* HACK: Align better with 14px–17px sibling font */
 }
+/* HACK: Align icon better with different `.text` of different font sizes */
+.type-icon { margin-top: 0.125em; } /* align well with 14–17px text */
+small.container .type-icon { margin-top: 0; } /* align well with 11–14px text */
+
 .close-button {
   margin-left: auto;
   /* FAQ: Ignore padding by moving over it */

--- a/client/src/components/_common/Message/Message.module.scss
+++ b/client/src/components/_common/Message/Message.module.scss
@@ -90,6 +90,8 @@ small.container .type-icon { margin-top: 0; } /* align well with 11–14px text 
   border-style: solid;
 
   /* Children */
+  /* FAQ: The stylelint issue exists only when `small.container .type-icon` rule is present, which is an undesirable hack, anyway */
+  /* stylelint-disable-next-line no-descending-specificity */
   & .type-icon {
     margin-right: 1rem;
   }

--- a/client/src/components/_common/Message/Message.test.js
+++ b/client/src/components/_common/Message/Message.test.js
@@ -128,10 +128,41 @@ describe('Message', () => {
         </Message>
       );
       const root = getByRole('status');
-      const modifierClassName = MSG.SCOPE_MAP[scope || MSG.DEFAULT_SCOPE];
+      const modifierClassName = MSG.SCOPE_MAP[scope || MSG.DEFAULT_SCOPE].className;
 
       testClassnamesByType(TEST_TYPE, getByRole, getByTestId);
       expect(root.className).toMatch(new RegExp(modifierClassName));
+    });
+    it.each(MSG.SCOPES)('has accurate tagName when scope is "%s"', scope => {
+      const { getByRole, getByTestId } = render(
+        <Message
+          type={TEST_TYPE}
+          scope={scope}
+        >
+          {TEST_CONTENT}
+        </Message>
+      );
+      const root = getByRole('status');
+      const tagName = MSG.SCOPE_MAP[scope || MSG.DEFAULT_SCOPE].tagName;
+
+      testClassnamesByType(TEST_TYPE, getByRole, getByTestId);
+      expect(root.tagName.toLowerCase()).toMatch(tagName);
+    });
+    it.each(MSG.SCOPES)('has accurate tagName when tagName is provided for scope "%s"', scope => {
+      const { getByRole, getByTestId } = render(
+        <Message
+          type={TEST_TYPE}
+          scope={scope}
+          tagName="small"
+        >
+          {TEST_CONTENT}
+        </Message>
+      );
+      const root = getByRole('status');
+      const tagName = 'small';
+
+      testClassnamesByType(TEST_TYPE, getByRole, getByTestId);
+      expect(root.tagName.toLowerCase()).toMatch(tagName);
     });
   });
 


### PR DESCRIPTION
## Overview: ##

Allow `tagName` prop on `<Message>`\* (so that `<small>` text is supported, for success message in [FP-740](https://jira.tacc.utexas.edu/browse/FP-740) in PR #265).

> \* And `<inlineMessage>` and `<SectionMessage>`.

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [FP-740](https://jira.tacc.utexas.edu/browse/FP-740) (which has UI that requires `<small>` text in an `<InlineMessage>`)

## Summary of Changes: ##

- __New__: Add `tagName` prop.
- __New__: Isolate and extend hack for message icon alignment.
- __New__: Test `tagName` given different `scope`.
- __New__: Test `tagName` prop.

## Testing Steps: ##
1. Edit `UIPatternsMessage.js`.
1. Add attribute `tagName="small"` to any `<InlineMessage>`.
1. Add attribute `tagName="small"` to any `<SectionMessage>`.
1. Ensure affected messages' icon and text are (roughly) vertically aligned along a central axis.

## UI Photos:

- No small text.
  _The visual appearance of normal messages does **not** change._
  ![Message UI Pattern - Normal](https://user-images.githubusercontent.com/62723358/102150527-68a91680-3e36-11eb-8be4-97bab5689c48.png)
- Small text messages with alignment bug that _would_ happen _if **not** fixed_ (compare to next image).
  _The checkmark is aligned further beneath the text baseline than it should be. It does **not** appear vertically centered._
  ![Message UI Pattern - Sample Small Text (Alignment Bug)](https://user-images.githubusercontent.com/62723358/102150530-6941ad00-3e36-11eb-971b-051d5ba6672e.png)
- Small text messages with alignment as expected.
  _The checkmark is aligned just enough beneath the text baseline to appear vertically centered._
  ![Message UI Pattern - Sample Small Text (Alignment Hack)](https://user-images.githubusercontent.com/62723358/102150531-69da4380-3e36-11eb-882e-cb6cd74c5f57.png)

## Notes: ##

This support is added solely for the design pattern introduced in FP-740 ([small-but-otherwise-standard inline message with modal form buttons](https://jira.tacc.utexas.edu/secure/attachment/14723/Late%20Design%20-%20Action%20Success.png)).

This support includes [forced alignment](https://user-images.githubusercontent.com/62723358/102151872-70b68580-3e39-11eb-982d-4728f128981c.png) of icons. If Design agrees that [natural alignment](https://user-images.githubusercontent.com/62723358/102151873-71e7b280-3e39-11eb-8648-b0a6ad06356b.png) is acceptable for normal and small text, then I will remove the hack from this branch/PR by manually merging the branch `quick/support-tagname-on-message--natural-alignment`.