### PR TITLE
task/FP-805: Configurable projects

### DIFF
--- a/client/src/components/DataFiles/DataFilesBreadcrumbs/DataFilesBreadcrumbs.js
+++ b/client/src/components/DataFiles/DataFilesBreadcrumbs/DataFilesBreadcrumbs.js
@@ -91,14 +91,10 @@ const DataFilesBreadcrumbs = ({
 
   const root = (() => {
     switch (scheme) {
-      case 'private':
-        return findSystemDisplayName(systemList, system);
-      case 'community':
-        return 'Community Data';
       case 'projects':
         return findProjectTitle(system);
       default:
-        return null;
+        return findSystemDisplayName(systemList, system);
     }
   })();
 

--- a/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.js
+++ b/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.js
@@ -89,34 +89,25 @@ const DataFilesSidebar = ({ readOnly }) => {
         </div>
         <div className="data-files-nav">
           <Nav vertical>
-            <NavItem>
-              {systems
-                ? systems.map(sys => (
+            {systems
+              ? systems.map(sys => (
+                  <NavItem>
                     <NavLink
                       tag={RRNavLink}
-                      to={`${match.path}/${sys.api}/${sys.scheme}/${sys.system}/`}
+                      to={`${match.path}/${sys.api}/${sys.scheme}/${
+                        sys.system ? `${sys.system}/` : ''
+                      }`}
                       activeClassName="active"
-                      key={sys.system}
+                      key={`${sys.name}`}
                     >
                       <div className="nav-content">
                         <Icon name={sys.icon || 'my-data'} />
                         <span className="nav-text">{sys.name}</span>
                       </div>
                     </NavLink>
-                  ))
-                : null}
-              <NavLink
-                tag={RRNavLink}
-                to={`${match.path}/tapis/projects`}
-                activeClassName="active"
-                key="workspaces"
-              >
-                <div className="nav-content">
-                  <Icon name="my-data" />
-                  <span className="nav-text">Shared Workspaces</span>
-                </div>
-              </NavLink>
-            </NavItem>
+                  </NavItem>
+                ))
+              : null}
           </Nav>
         </div>
       </div>

--- a/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.js
+++ b/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.js
@@ -70,9 +70,11 @@ const DataFilesSidebar = ({ readOnly }) => {
                   <i className="icon-folder" /> Folder
                 </span>
               </DropdownItem>
-              <DropdownItem onClick={toggleAddProjectModal}>
-                <i className="icon-folder" /> Shared Workspace
-              </DropdownItem>
+              {systems.some(s => s.scheme === 'projects') && (
+                <DropdownItem onClick={toggleAddProjectModal}>
+                  <i className="icon-folder" /> Shared Workspace
+                </DropdownItem>
+              )}
               <DropdownItem
                 className="complex-dropdown-item"
                 onClick={toggleUploadModal}

--- a/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.scss
+++ b/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.scss
@@ -6,6 +6,7 @@ $frontera-portal-color-primary: #9d85ef;
   background: #ffffff;
   padding-top: 10px;
   border-right: 1px solid rgba(112, 112, 112, 0.25);
+  height: 100%;
 }
 
 .data-files-sidebar .nav-link {

--- a/client/src/components/Sidebar/Sidebar.js
+++ b/client/src/components/Sidebar/Sidebar.js
@@ -16,7 +16,6 @@ const SidebarItem = ({ to, label, iconName, children, disabled }) => {
     <NavItem>
       <NavLink
         tag={RRNavLink}
-        exact
         to={to}
         styleName="link"
         activeStyleName="link--active"

--- a/server/portal/settings/settings_secret.example.py
+++ b/server/portal/settings/settings_secret.example.py
@@ -138,6 +138,50 @@ _PORTAL_JUPYTER_SYSTEM_MAP = {
     "cep.home.{username}": "/tacc-work",
 }
 
+_PORTAL_DATA_DEPOT_LOCAL_STORAGE_SYSTEM_DEFAULT = 'frontera'
+_PORTAL_DATA_DEPOT_LOCAL_STORAGE_SYSTEMS = {
+    'frontera': {
+        'name': 'My Data (Frontera)',
+        'description': 'My Data on Frontera for {username}',
+        'site': 'frontera',
+        'systemId': 'frontera.home.{username}',
+        'host': 'frontera.tacc.utexas.edu',
+        'rootDir': '/home1/{tasdir}',
+        'port': 22,
+        'icon': None,
+    },
+    'longhorn': {
+        'name': 'My Data (Longhorn)',
+        'description': 'My Data on Longhorn for {username}',
+        'site': 'frontera',
+        'systemId': 'longhorn.home.{username}',
+        'host': 'longhorn.tacc.utexas.edu',
+        'rootDir': '/home/{tasdir}',
+        'port': 22,
+        'requires_allocation': 'longhorn3',
+        'icon': None,
+    },
+}
+
+_PORTAL_DATAFILES_STORAGE_SYSTEMS = [
+    {
+        'name': 'Community Data',
+        'system': 'frontera.storage.community',
+        'scheme': 'community',
+        'api': 'tapis',
+        'icon': None
+    },
+    {
+        'name': 'Shared Workspaces',
+        'scheme': 'projects',
+        'api': 'tapis',
+        'icon': None
+    }
+]
+
+########################
+# DJANGO APP: ONBOARDING
+########################
 """
 Onboarding steps
 Each step is an object, with the full package name of the step class and
@@ -171,41 +215,6 @@ _PORTAL_USER_ACCOUNT_SETUP_STEPS = [
     {
         'step': 'portal.apps.onboarding.steps.system_creation.SystemCreationStep',
         'settings': {}
-    }
-]
-
-_PORTAL_DATA_DEPOT_LOCAL_STORAGE_SYSTEM_DEFAULT = 'frontera'
-_PORTAL_DATA_DEPOT_LOCAL_STORAGE_SYSTEMS = {
-    'frontera': {
-        'name': 'My Data (Frontera)',
-        'description': 'My Data on Frontera for {username}',
-        'site': 'frontera',
-        'systemId': 'frontera.home.{username}',
-        'host': 'frontera.tacc.utexas.edu',
-        'rootDir': '/home1/{tasdir}',
-        'port': 22,
-        'icon': None,
-    },
-    'longhorn': {
-        'name': 'My Data (Longhorn)',
-        'description': 'My Data on Longhorn for {username}',
-        'site': 'frontera',
-        'systemId': 'longhorn.home.{username}',
-        'host': 'longhorn.tacc.utexas.edu',
-        'rootDir': '/home/{tasdir}',
-        'port': 22,
-        'requires_allocation': 'longhorn3',
-        'icon': None,
-    },
-}
-
-_PORTAL_DATAFILES_STORAGE_SYSTEMS = [
-    {
-        'name': 'Community Data',
-        'system': 'frontera.storage.community',
-        'scheme': 'community',
-        'api': 'tapis',
-        'icon': None
     }
 ]
 


### PR DESCRIPTION
## Overview: ##
Uses the existing `_PORTAL_DATAFILES_STORAGE_SYSTEMS` secret setting to list Shared Workspaces (Projects) in the Data Files sidebar.

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [FP-805](https://jira.tacc.utexas.edu/browse/FP-805)

## Summary of Changes: ##
- Fixes active state of main sidebar when viewing a child view (i.e. `allocations/active`)
- Uses the `findSystemDisplayName` function as the default to set the root of data files breadcrumbs
- Projects are listed in the datefiles sidebar only if entered into the `_PORTAL_DATAFILES_STORAGE_SYSTEMS` secret setting

## Testing Steps: ##
1. Make the following block appear in `settings_secret.py`
```
_PORTAL_DATAFILES_STORAGE_SYSTEMS = [
    {
        'name': 'Community Data',
        'system': _AGAVE_COMMUNITY_DATA_SYSTEM,
        'scheme': 'community',
        'api': 'tapis',
        'icon': None
    },
    {
        'name': 'Shared Workspaces',
        'scheme': 'projects',
        'api': 'tapis',
        'icon': None
    }
]
```
2. If projects (Shared Workspaces) have not been set up locally, follow the testing steps in[ this PR](https://github.com/TACC/Frontera-Portal/pull/268)
3. Confirm "Shared Workspaces" appears in the data files sidebar, and is navigable as usual.
4. Remove the "Shared Workspaces" block from `_PORTAL_DATAFILES_STORAGE_SYSTEMS` and confirm that "Shared Workspaces" no longer appears in the frontend.

## UI Photos:
<img width="574" alt="Screen Shot 2020-12-15 at 12 11 31 AM" src="https://user-images.githubusercontent.com/20326896/102178023-49c47780-3e6a-11eb-8229-56f66cf67790.png">
<img width="415" alt="Screen Shot 2020-12-15 at 12 12 15 AM" src="https://user-images.githubusercontent.com/20326896/102178025-49c47780-3e6a-11eb-9b33-8604fcb7955c.png">

## Notes: ##
