### PR TITLE
Allow None values to propagate without string conversion (fixes null …

### DIFF
--- a/server/portal/apps/projects/serializers.py
+++ b/server/portal/apps/projects/serializers.py
@@ -55,7 +55,10 @@ class MetadataJSONSerializer(json.JSONEncoder):
                     if related is not None:
                         ret[attname] = _seralize_user(related)
                 else:
-                    ret[attname] = field.value_to_string(obj)
+                    if val == None:
+                        ret[attname] = None
+                    else:
+                        ret[attname] = field.value_to_string(obj)
             for field in obj._meta.many_to_many:
                 if not field.serialize:
                     continue


### PR DESCRIPTION
## Overview: ##

Allows None values in ProjectMetadata to skip string conversion to "None". (Allows null description)

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [FP-807](https://jira.tacc.utexas.edu/browse/FP-807)

## Summary of Changes: ##

## Testing Steps: ##
1. Create a project with no description
2. Make sure it's empty

## UI Photos:

## Notes: ##
