### PR TITLE
bugfix task/FP-811: Fix View Path modal for project systems

### DIFF
--- a/client/src/components/DataFiles/DataFilesModals/DataFilesShowPathModal.js
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesShowPathModal.js
@@ -33,7 +33,7 @@ const DataFilesShowPathModal = React.memo(() => {
   });
 
   const isOpen = useSelector(
-    state => state.files.modals.showpath && definition
+    state => state.files.modals.showpath && Boolean(definition)
   );
 
   const toggle = () =>

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesShowPathModal.js
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesShowPathModal.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useSelector, useDispatch, shallowEqual } from 'react-redux';
 import { Modal, ModalHeader, ModalBody } from 'reactstrap';
 import { TextCopyField } from '_common';
@@ -10,19 +10,39 @@ const DataFilesShowPathModal = React.memo(() => {
     state => state.files.params.FilesListing,
     shallowEqual
   );
+
+  useEffect(
+    () => {
+      if (params.api === 'tapis' && params.system) {
+        dispatch({
+          type: 'FETCH_SYSTEM_DEFINITION',
+          payload: params.system
+        })
+      }
+    },
+    [ params, dispatch ]
+  );
+
   const { file } = useSelector(state => state.files.modalProps.showpath);
 
   const definition = useSelector(state => {
+    console.log(state.systems);
     if (!file) {
       return null;
     }
-    const matching = state.systems.systemList.find(
+    let matching = state.systems.systemList.find(
       sys => sys.system === file.system
     );
-    if (!matching) {
-      return null;
+    if (matching) {
+      return matching.definition;
     }
-    return matching.definition;
+    matching = state.systems.definitions.find(
+      sys => sys.id === file.system
+    )
+    if (matching) {
+      return matching;
+    }
+    return null;
   });
 
   const isOpen = useSelector(

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesShowPathModal.js
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesShowPathModal.js
@@ -26,23 +26,13 @@ const DataFilesShowPathModal = React.memo(() => {
   const { file } = useSelector(state => state.files.modalProps.showpath);
 
   const definition = useSelector(state => {
-    console.log(state.systems);
     if (!file) {
       return null;
     }
-    let matching = state.systems.systemList.find(
-      sys => sys.system === file.system
-    );
-    if (matching) {
-      return matching.definition;
-    }
-    matching = state.systems.definitions.find(
+    const matching = state.systems.definitions.find(
       sys => sys.id === file.system
     )
-    if (matching) {
-      return matching;
-    }
-    return null;
+    return matching;
   });
 
   const isOpen = useSelector(

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesShowPathModal.js
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesShowPathModal.js
@@ -11,17 +11,14 @@ const DataFilesShowPathModal = React.memo(() => {
     shallowEqual
   );
 
-  useEffect(
-    () => {
-      if (params.api === 'tapis' && params.system) {
-        dispatch({
-          type: 'FETCH_SYSTEM_DEFINITION',
-          payload: params.system
-        })
-      }
-    },
-    [ params, dispatch ]
-  );
+  useEffect(() => {
+    if (params.api === 'tapis' && params.system) {
+      dispatch({
+        type: 'FETCH_SYSTEM_DEFINITION',
+        payload: params.system
+      });
+    }
+  }, [params, dispatch]);
 
   const { file } = useSelector(state => state.files.modalProps.showpath);
 
@@ -31,7 +28,7 @@ const DataFilesShowPathModal = React.memo(() => {
     }
     const matching = state.systems.definitions.find(
       sys => sys.id === file.system
-    )
+    );
     return matching;
   });
 

--- a/client/src/components/DataFiles/DataFilesModals/tests/DataFilesShowPathModal.test.js
+++ b/client/src/components/DataFiles/DataFilesModals/tests/DataFilesShowPathModal.test.js
@@ -4,6 +4,7 @@ import DataFilesShowPathModal from '../DataFilesShowPathModal';
 import configureStore from 'redux-mock-store';
 import DataFilesShowPathModalFixture from './DataFilesShowPathModal.fixture';
 import systemsFixture from '../../fixtures/DataFiles.systems.fixture';
+import projectsFixture from '../../../../redux/sagas/fixtures/projects.fixture';
 import renderComponent from 'utils/testing';
 
 const mockStore = configureStore();
@@ -11,12 +12,13 @@ const mockStore = configureStore();
 const initialMockState = {
   files: DataFilesShowPathModalFixture,
   systems: systemsFixture,
+  projects: projectsFixture
 };
 
 describe('DataFilesShowPathModal', () => {
   it('renders the showpath modal', () => {
     const history = createMemoryHistory();
-    history.push('/workbench/data/tapis/private/test.system/');
+    history.push('/workbench/data/tapis/private/frontera.home.username/');
     const store = mockStore(initialMockState);
 
     const { getAllByText } = renderComponent(

--- a/client/src/components/DataFiles/DataFilesModals/tests/DataFilesShowPathModal.test.js
+++ b/client/src/components/DataFiles/DataFilesModals/tests/DataFilesShowPathModal.test.js
@@ -4,7 +4,7 @@ import DataFilesShowPathModal from '../DataFilesShowPathModal';
 import configureStore from 'redux-mock-store';
 import DataFilesShowPathModalFixture from './DataFilesShowPathModal.fixture';
 import systemsFixture from '../../fixtures/DataFiles.systems.fixture';
-import projectsFixture from '../../../../redux/sagas/fixtures/projects.fixture';
+import { projectsFixture } from '../../../../redux/sagas/fixtures/projects.fixture';
 import renderComponent from 'utils/testing';
 
 const mockStore = configureStore();

--- a/client/src/components/DataFiles/fixtures/DataFiles.systems.fixture.js
+++ b/client/src/components/DataFiles/fixtures/DataFiles.systems.fixture.js
@@ -5,30 +5,34 @@ const systemsFixture = {
       name: 'My Data (Frontera)',
       system: 'frontera.home.username',
       scheme: 'private',
-      api: 'tapis',
-      definition: {
-        storage: {
-          host: 'frontera.tacc.utexas.edu',
-          rootDir: '/home1/012345/username'
-        }
-      }
+      api: 'tapis'
     },
     {
       name: 'My Data (Longhorn)',
       system: 'longhorn.home.username',
       scheme: 'private',
-      api: 'tapis',
-      definition: {
-        storage: {
-          host: 'longhorn.tacc.utexas.edu',
-          rootDir: '/home/012345/username'
-        }
-      }
+      api: 'tapis'
     },
     {
       name: 'Shared Workspaces',
       scheme: 'projects',
       api: 'tapis'
+    }
+  ],
+  definitions: [
+    {
+      id: 'frontera.home.username',
+      storage: {
+        host: 'frontera.tacc.utexas.edu',
+        rootDir: '/home1/012345/username'
+      }
+    },
+    {
+      id: 'longhorn.home.username',
+      storage: {
+        host: 'longhorn.tacc.utexas.edu',
+        rootDir: '/home/012345/username'
+      }
     }
   ]
 };

--- a/client/src/components/_common/TextCopyField/TextCopyField.js
+++ b/client/src/components/_common/TextCopyField/TextCopyField.js
@@ -39,7 +39,7 @@ const TextCopyField = ({ value, placeholder }) => {
         className="form-control"
         placeholder={placeholder}
         data-testid="input"
-        readOnly={isEmpty}
+        readOnly
       />
     </div>
   );

--- a/client/src/redux/reducers/datafiles.reducers.js
+++ b/client/src/redux/reducers/datafiles.reducers.js
@@ -2,19 +2,58 @@ export const initialSystemState = {
   defaultHost: '',
   systemList: [],
   error: false,
-  errorMessage: null
+  errorMessage: null,
+  loading: false,
+  definitions: [],
 };
+
+export const addSystemDefinition = (system, definitionList) => {
+  return [
+    ...definitionList.filter(existing => existing.id !== system.id),
+    system
+  ]
+}
 
 export function systems(state = initialSystemState, action) {
   switch (action.type) {
+    case 'FETCH_SYSTEMS_STARTED':
+      return {
+        ...state,
+        error: false,
+        errorMessage: null,
+        loading: true
+      }
     case 'FETCH_SYSTEMS_SUCCESS':
       return {
         ...state,
         systemList: action.payload.system_list,
-        defaultHost: action.payload.default_host
+        defaultHost: action.payload.default_host,
+        loading: false
       };
     case 'FETCH_SYSTEMS_ERROR':
-      return { ...state, error: true, errorMessage: action.payload };
+      return { ...state, error: true, errorMessage: action.payload, loading: false };
+    case 'FETCH_SYSTEM_DEFINITION_STARTED':
+      return {
+        ...state,
+        error: false,
+        errorMessage: null,
+        loading: true
+      }
+    case 'FETCH_SYSTEM_DEFINITION_SUCCESS':
+      return {
+        ...state,
+        definitions: addSystemDefinition(action.payload, state.definitions),
+        error: false,
+        errorMessage: null,
+        loading: false
+      }
+    case 'FETCH_SYSTEM_DEFINITION_ERROR':
+      return {
+        ...state,
+        error: true,
+        errorMessage: action.payload,
+        loading: false
+      }
     default:
       return state;
   }

--- a/client/src/redux/reducers/datafiles.reducers.js
+++ b/client/src/redux/reducers/datafiles.reducers.js
@@ -4,15 +4,15 @@ export const initialSystemState = {
   error: false,
   errorMessage: null,
   loading: false,
-  definitions: [],
+  definitions: []
 };
 
 export const addSystemDefinition = (system, definitionList) => {
   return [
     ...definitionList.filter(existing => existing.id !== system.id),
     system
-  ]
-}
+  ];
+};
 
 export function systems(state = initialSystemState, action) {
   switch (action.type) {
@@ -22,7 +22,7 @@ export function systems(state = initialSystemState, action) {
         error: false,
         errorMessage: null,
         loading: true
-      }
+      };
     case 'FETCH_SYSTEMS_SUCCESS':
       return {
         ...state,
@@ -31,14 +31,19 @@ export function systems(state = initialSystemState, action) {
         loading: false
       };
     case 'FETCH_SYSTEMS_ERROR':
-      return { ...state, error: true, errorMessage: action.payload, loading: false };
+      return {
+        ...state,
+        error: true,
+        errorMessage: action.payload,
+        loading: false
+      };
     case 'FETCH_SYSTEM_DEFINITION_STARTED':
       return {
         ...state,
         error: false,
         errorMessage: null,
         loading: true
-      }
+      };
     case 'FETCH_SYSTEM_DEFINITION_SUCCESS':
       return {
         ...state,
@@ -46,14 +51,14 @@ export function systems(state = initialSystemState, action) {
         error: false,
         errorMessage: null,
         loading: false
-      }
+      };
     case 'FETCH_SYSTEM_DEFINITION_ERROR':
       return {
         ...state,
         error: true,
         errorMessage: action.payload,
         loading: false
-      }
+      };
     default:
       return state;
   }

--- a/client/src/redux/sagas/datafiles.sagas.js
+++ b/client/src/redux/sagas/datafiles.sagas.js
@@ -22,6 +22,7 @@ export async function fetchSystemsUtil() {
 }
 
 export function* fetchSystems() {
+  yield put({ type: 'FETCH_SYSTEMS_STARTED' });
   try {
     const systemsJson = yield call(fetchSystemsUtil);
     yield put({ type: 'FETCH_SYSTEMS_SUCCESS', payload: systemsJson });
@@ -30,10 +31,30 @@ export function* fetchSystems() {
   }
 }
 
+export async function fetchSystemDefinitionUtil(system) {
+  const response = await fetch(`/api/datafiles/systems/definition/${system}/`)
+  if (!response.ok) {
+    throw new Error(response.status);
+  }
+  const responseJson = await response.json();
+  return responseJson;
+}
+
+export function* fetchSystemDefinition(action) {
+  yield put({ type: 'FETCH_SYSTEM_DEFINITION_STARTED' });
+  try {
+    const systemsJson = yield call(fetchSystemDefinitionUtil, action.payload);
+    yield put({ type: 'FETCH_SYSTEM_DEFINITION_SUCCESS', payload: systemsJson});
+  } catch(e) {
+    yield put({ type: 'FETCH_SYSTEM_DEFINITION_ERROR', payload: e.message });
+  }
+}
+
 export function* watchFetchSystems() {
   // The result of the systems call shouldn't change so we only care about
   // the first result.
   yield takeLeading('FETCH_SYSTEMS', fetchSystems);
+  yield takeLeading('FETCH_SYSTEM_DEFINITION', fetchSystemDefinition);
 }
 
 export async function pushKeysUtil(system, form) {

--- a/client/src/redux/sagas/datafiles.sagas.js
+++ b/client/src/redux/sagas/datafiles.sagas.js
@@ -32,7 +32,7 @@ export function* fetchSystems() {
 }
 
 export async function fetchSystemDefinitionUtil(system) {
-  const response = await fetch(`/api/datafiles/systems/definition/${system}/`)
+  const response = await fetch(`/api/datafiles/systems/definition/${system}/`);
   if (!response.ok) {
     throw new Error(response.status);
   }
@@ -44,8 +44,11 @@ export function* fetchSystemDefinition(action) {
   yield put({ type: 'FETCH_SYSTEM_DEFINITION_STARTED' });
   try {
     const systemsJson = yield call(fetchSystemDefinitionUtil, action.payload);
-    yield put({ type: 'FETCH_SYSTEM_DEFINITION_SUCCESS', payload: systemsJson});
-  } catch(e) {
+    yield put({
+      type: 'FETCH_SYSTEM_DEFINITION_SUCCESS',
+      payload: systemsJson
+    });
+  } catch (e) {
     yield put({ type: 'FETCH_SYSTEM_DEFINITION_ERROR', payload: e.message });
   }
 }

--- a/server/conftest.py
+++ b/server/conftest.py
@@ -1,6 +1,9 @@
 import pytest
+import json
+import os
 from portal.apps.auth.models import AgaveOAuthToken
 from portal.apps.accounts.models import PortalProfile
+from django.conf import settings
 
 
 @pytest.fixture
@@ -76,3 +79,8 @@ def staff_user(client, django_user_model, django_db_reset_sequences, mock_agave_
 def authenticated_staff(client, staff_user):
     client.force_login(staff_user)
     return staff_user
+
+
+@pytest.fixture
+def agave_storage_system_mock():
+    yield json.load(open(os.path.join(settings.BASE_DIR, 'fixtures/agave/systems/storage.json')))

--- a/server/portal/apps/datafiles/urls.py
+++ b/server/portal/apps/datafiles/urls.py
@@ -1,12 +1,14 @@
 from django.urls import path
 from portal.apps.datafiles.views import (TapisFilesView,
                                          LinkView,
-                                         SystemListingView)
+                                         SystemListingView,
+                                         SystemDefinitionView)
 
 
 app_name = 'users'
 urlpatterns = [
     path('systems/list/', SystemListingView.as_view()),
+    path('systems/definition/<str:system>/', SystemDefinitionView.as_view()),
     path('tapis/<str:operation>/<str:scheme>/<str:system>/',
          TapisFilesView.as_view()),
     path('tapis/<str:operation>/<str:scheme>/<str:system>/<path:path>/',

--- a/server/portal/apps/datafiles/views.py
+++ b/server/portal/apps/datafiles/views.py
@@ -46,16 +46,6 @@ class SystemListingView(BaseApiView):
         response['system_list'] += portal_systems
         default_system = user_systems[settings.PORTAL_DATA_DEPOT_LOCAL_STORAGE_SYSTEM_DEFAULT]
         response['default_host'] = default_system['host']
-
-        for system in response['system_list']:
-            try:
-                if system['api'] == 'tapis' and 'system' in system:
-                    system['definition'] = StorageSystem(
-                        request.user.agave_oauth.client, id=system['system']
-                    )
-            except Exception:
-                logger.exception("Could not retrieve definition for {}".format(system['system']))
-
         return JsonResponse(response, encoder=BaseAgaveSystemSerializer)
 
 

--- a/server/portal/apps/datafiles/views.py
+++ b/server/portal/apps/datafiles/views.py
@@ -1,5 +1,4 @@
 import json
-import logging
 from django.conf import settings
 from django.http import JsonResponse, HttpResponseForbidden
 from requests.exceptions import HTTPError
@@ -14,8 +13,6 @@ from portal.apps.datafiles.models import Link
 from portal.exceptions.api import ApiException
 from django.contrib.auth.decorators import login_required
 from django.utils.decorators import method_decorator
-from portal.libs.agave.models.systems.storage import StorageSystem
-from portal.libs.agave.serializers import BaseAgaveSystemSerializer
 from .utils import notify, NOTIFY_ACTIONS
 import logging
 
@@ -49,11 +46,12 @@ class SystemListingView(BaseApiView):
         return JsonResponse(response)
 
 
+@method_decorator(login_required, name='dispatch')
 class SystemDefinitionView(BaseApiView):
     """Get definitions for individual systems"""
-
     def get(self, request, system):
         return JsonResponse(request.user.agave_oauth.client.systems.get(systemId=system))
+
 
 class TapisFilesView(BaseApiView):
     def get(self, request, operation=None, scheme=None, system=None, path='/'):

--- a/server/portal/apps/datafiles/views.py
+++ b/server/portal/apps/datafiles/views.py
@@ -46,7 +46,7 @@ class SystemListingView(BaseApiView):
         response['system_list'] += portal_systems
         default_system = user_systems[settings.PORTAL_DATA_DEPOT_LOCAL_STORAGE_SYSTEM_DEFAULT]
         response['default_host'] = default_system['host']
-        return JsonResponse(response, encoder=BaseAgaveSystemSerializer)
+        return JsonResponse(response)
 
 
 class SystemDefinitionView(BaseApiView):

--- a/server/portal/apps/datafiles/views.py
+++ b/server/portal/apps/datafiles/views.py
@@ -59,6 +59,12 @@ class SystemListingView(BaseApiView):
         return JsonResponse(response, encoder=BaseAgaveSystemSerializer)
 
 
+class SystemDefinitionView(BaseApiView):
+    """Get definitions for individual systems"""
+
+    def get(self, request, system):
+        return JsonResponse(request.user.agave_oauth.client.systems.get(systemId=system))
+
 class TapisFilesView(BaseApiView):
     def get(self, request, operation=None, scheme=None, system=None, path='/'):
         try:

--- a/server/portal/apps/datafiles/views_unit_test.py
+++ b/server/portal/apps/datafiles/views_unit_test.py
@@ -139,3 +139,18 @@ def test_generate_notification_on_request(client, authenticated_user, mocker, mo
     n = Notification.objects.last()
     extra_from_notification = n.to_dict()['extra']
     assert extra_from_notification == {'response': mock_response}
+
+
+def test_get_system(client, authenticated_user, mock_agave_client, agave_storage_system_mock):
+    mock_agave_client.systems.get.return_value = agave_storage_system_mock
+
+    response = client.get("/api/datafiles/systems/definition/MySystem/")
+    assert response.status_code == 200
+    assert response.json() == agave_storage_system_mock
+
+
+def test_get_system_forbidden(client, regular_user, mock_agave_client, agave_storage_system_mock):
+    mock_agave_client.systems.get.return_value = agave_storage_system_mock
+
+    response = client.get("/api/datafiles/systems/definition/MySystem/")
+    assert response.status_code == 302 # redirect to login


### PR DESCRIPTION
## Overview: ##

Fix view path for projects by retrieving project system definitions

## PR Status: ##

* [x] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [FP-213](https://jira.tacc.utexas.edu/browse/FP-213)
* [FP-692](https://jira.tacc.utexas.edu/browse/FP-692)

## Summary of Changes: ##

- Added /api/systems/definitions/<str:system> end point
- Reducer now keeps a list of other system definitions (in addition to the systemList for the sidebar)
- DataFilesShowPathModal retrieves system definition of viewed system

## Testing Steps: ##
1. 

## UI Photos:

## Notes: ##
- Needs tests and to fix broken tests
