### PR TITLE
Projects: tweak modal layout

### DIFF
--- a/client/src/components/Dashboard/Dashboard.scss
+++ b/client/src/components/Dashboard/Dashboard.scss
@@ -55,6 +55,9 @@
 /* RFC: Class name `.dashboard-item` (to coincide with `.dashboard-items`) */
 .dash-grid-item {
     margin-top: 20px;
+    .InfiniteScrollTable {
+        border-bottom: 1px solid #707070;
+    }
 }
 
 .sysmon-wrapper {

--- a/client/src/components/DataFiles/DataFilesListing/DataFilesListingCells.js
+++ b/client/src/components/DataFiles/DataFilesListing/DataFilesListingCells.js
@@ -165,7 +165,9 @@ FileIconCell.propTypes = {
 
 export const ViewPathCell = ({ file }) => {
   const dispatch = useDispatch();
-  const onClick = () => {
+  const onClick = e => {
+    e.stopPropagation();
+    e.preventDefault();
     dispatch({
       type: 'DATA_FILES_TOGGLE_MODAL',
       payload: { operation: 'showpath', props: { file } }

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesModals.scss
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesModals.scss
@@ -41,6 +41,22 @@
     .modal-title {
       font-size: 18px;
     }
+
+    .InfiniteScrollTable.projects-listing {
+      th {
+        color: #484848;
+      }
+      th,
+      td {
+        display: flex;
+        align-items: center;
+        font-size: 12px;
+        padding: 5px 15px;
+      }
+      td {
+        height: 45px;
+      }
+    }
 }
 
 /* Quick port of inline style to stylesheet */

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesShowPathModal.js
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesShowPathModal.js
@@ -42,13 +42,6 @@ const DataFilesShowPathModal = React.memo(() => {
       payload: { operation: 'showpath', props: {} }
     });
 
-  const onOpened = () => {
-    dispatch({
-      type: 'FETCH_FILES_MODAL',
-      payload: { ...params, section: 'modal' }
-    });
-  };
-
   const onClosed = () => {
     dispatch({ type: 'DATA_FILES_MODAL_CLOSE' });
   };
@@ -57,7 +50,6 @@ const DataFilesShowPathModal = React.memo(() => {
     file && (
       <Modal
         isOpen={isOpen}
-        onOpened={onOpened}
         onClosed={onClosed}
         toggle={toggle}
         className="dataFilesModal"

--- a/client/src/components/DataFiles/DataFilesProjectsList/DataFilesProjectsList.js
+++ b/client/src/components/DataFiles/DataFilesProjectsList/DataFilesProjectsList.js
@@ -79,10 +79,6 @@ const DataFilesProjectsList = ({ modal }) => {
 
   const noDataText = "You don't have any Shared Workspaces.";
 
-  if (loading) {
-    return <LoadingSpinner />;
-  }
-
   if (error) {
     return (
       <Message type="error">

--- a/client/src/components/DataFiles/DataFilesProjectsList/DataFilesProjectsList.js
+++ b/client/src/components/DataFiles/DataFilesProjectsList/DataFilesProjectsList.js
@@ -2,7 +2,7 @@ import React, { useEffect, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
-import { InfiniteScrollTable, LoadingSpinner, Message } from '_common';
+import { InfiniteScrollTable, Message } from '_common';
 import './DataFilesProjectsList.module.scss';
 import './DataFilesProjectsList.scss';
 

--- a/client/src/components/DataFiles/DataFilesProjectsList/DataFilesProjectsList.scss
+++ b/client/src/components/DataFiles/DataFilesProjectsList/DataFilesProjectsList.scss
@@ -1,5 +1,4 @@
 .projects-listing {
-  width: inherit;
   flex-grow: 1;
   th {
     color: #484848;

--- a/client/src/components/DataFiles/DataFilesSystemSelector/DataFilesSystemSelector.js
+++ b/client/src/components/DataFiles/DataFilesSystemSelector/DataFilesSystemSelector.js
@@ -87,7 +87,12 @@ const DataFilesSystemSelector = ({
         )}
       </DropdownSelector>
       {selectedSystem === 'shared' && !showProjects && (
-        <button type="button" className="btn btn-link" onClick={resetProjects}>
+        <button
+          type="button"
+          className="btn btn-link"
+          styleName="btn-shared"
+          onClick={resetProjects}
+        >
           Return to Shared Workspaces
         </button>
       )}

--- a/client/src/components/DataFiles/DataFilesSystemSelector/DataFilesSystemSelector.module.scss
+++ b/client/src/components/DataFiles/DataFilesSystemSelector/DataFilesSystemSelector.module.scss
@@ -7,5 +7,5 @@
 }
 
 .btn-shared {
-  padding: 0
+  padding: 0;
 }

--- a/client/src/components/DataFiles/DataFilesSystemSelector/DataFilesSystemSelector.module.scss
+++ b/client/src/components/DataFiles/DataFilesSystemSelector/DataFilesSystemSelector.module.scss
@@ -5,3 +5,7 @@
   display: inline-block;
   vertical-align: text-bottom;
 }
+
+.btn-shared {
+  padding: 0
+}

--- a/client/src/components/_common/InfiniteScrollTable/InfiniteScrollTable.scss
+++ b/client/src/components/_common/InfiniteScrollTable/InfiniteScrollTable.scss
@@ -7,7 +7,6 @@
   align-items: stretch;
   width: 100%;
   overflow: scroll;
-  border-bottom: 1px solid #707070;
   max-height: inherit; /* inherit max-height from parent wrapper */
   font-size: 0.78em;
 

--- a/client/src/redux/sagas/datafiles.sagas.js
+++ b/client/src/redux/sagas/datafiles.sagas.js
@@ -31,8 +31,10 @@ export function* fetchSystems() {
   }
 }
 
-export async function fetchSystemDefinitionUtil(system) {
-  const response = await fetch(`/api/datafiles/systems/definition/${system}/`);
+export async function fetchSystemDefinitionUtil(systemId) {
+  const response = await fetch(
+    `/api/datafiles/systems/definition/${systemId}/`
+  );
   if (!response.ok) {
     throw new Error(response.status);
   }
@@ -43,10 +45,10 @@ export async function fetchSystemDefinitionUtil(system) {
 export function* fetchSystemDefinition(action) {
   yield put({ type: 'FETCH_SYSTEM_DEFINITION_STARTED' });
   try {
-    const systemsJson = yield call(fetchSystemDefinitionUtil, action.payload);
+    const systemJson = yield call(fetchSystemDefinitionUtil, action.payload);
     yield put({
       type: 'FETCH_SYSTEM_DEFINITION_SUCCESS',
-      payload: systemsJson
+      payload: systemJson
     });
   } catch (e) {
     yield put({ type: 'FETCH_SYSTEM_DEFINITION_ERROR', payload: e.message });

--- a/server/portal/apps/datafiles/urls.py
+++ b/server/portal/apps/datafiles/urls.py
@@ -8,7 +8,7 @@ from portal.apps.datafiles.views import (TapisFilesView,
 app_name = 'users'
 urlpatterns = [
     path('systems/list/', SystemListingView.as_view()),
-    path('systems/definition/<str:system>/', SystemDefinitionView.as_view()),
+    path('systems/definition/<str:systemId>/', SystemDefinitionView.as_view()),
     path('tapis/<str:operation>/<str:scheme>/<str:system>/',
          TapisFilesView.as_view()),
     path('tapis/<str:operation>/<str:scheme>/<str:system>/<path:path>/',

--- a/server/portal/apps/datafiles/views.py
+++ b/server/portal/apps/datafiles/views.py
@@ -49,8 +49,8 @@ class SystemListingView(BaseApiView):
 @method_decorator(login_required, name='dispatch')
 class SystemDefinitionView(BaseApiView):
     """Get definitions for individual systems"""
-    def get(self, request, system):
-        return JsonResponse(request.user.agave_oauth.client.systems.get(systemId=system))
+    def get(self, request, systemId):
+        return JsonResponse(request.user.agave_oauth.client.systems.get(systemId=systemId))
 
 
 class TapisFilesView(BaseApiView):


### PR DESCRIPTION
## Overview: ##
CSS tweaks to projects layout in data files modals
<img width="1075" alt="Screen Shot 2020-12-17 at 4 47 50 PM" src="https://user-images.githubusercontent.com/20326896/102552921-9df87300-4087-11eb-9cd6-5e5306c895dc.png">


## PR Status: ##

* [X] Ready.

## Notes: ##
- I opted to leave the shared workspace file listing header above the normal height of the listing, as it could make sense for headers to be higher. However, I couldn't remove the outline of the header, since it is a child element of the container that has the outline.
- This addresses the long project name overflow problem