### PR TITLE
FP-597: Reduce horizontal padding on appDetail container

### DIFF
--- a/client/src/components/Applications/AppForm/AppForm.scss
+++ b/client/src/components/Applications/AppForm/AppForm.scss
@@ -78,5 +78,5 @@
     justify-content: center;
     height: 100%; /* Be consistent with `#appDetail-wrapper`/`.app-placeholder` (which can exist at the same location),
                      so that `appBrowser-wrapper` height does not change based on sibling content */
-    padding: 30px;
+    padding: 30px 0;
 }


### PR DESCRIPTION
## Overview: ##

Tweak UI of small PR that did not previously edit CSS.

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [FP-597](https://jira.tacc.utexas.edu/browse/FP-597)

## Summary of Changes: ##

- __Fix__: Remove the undesirable padding (which was usually invisible before¹²).

¹ The use of `<Sectionmessage>` makes the padding visible.
² Before, the padding was invisible on most screens, cuz message is short.

## Testing Steps: ##
1. Load app to which you have no access.
    - Check that `<SectionMessage>` does not have extra horizontal negative space.
1. Successfully submit a job.
    - Check that `<SectionMessage>` does not have extra horizontal negative space.
1. Load app that cannot be loaded.
    - Check that `<SectionMessage>` looks the same (space removal is not a visible change).

## UI Photos:

- __App No Access__
  ![App No Access](https://user-images.githubusercontent.com/62723358/102552919-9d5fdc80-4087-11eb-8a64-3f70150f5b1a.png)

- __App No Load__
  ![App No Load](https://user-images.githubusercontent.com/62723358/102552924-9f29a000-4087-11eb-8b55-b10077ba9d0c.png)

- __App Job Submit Success__
  (no image, change is identical to "App No Load")

## Notes: ##

I add a little complication by adding a CSS change, but it is minor, and I __know__ the extra space is not desired.