### PR TITLE
task/FP-815 - prevent View Path from appearing when browsing Google Drive

### DIFF
--- a/client/src/components/DataFiles/DataFilesListing/DataFilesListing.js
+++ b/client/src/components/DataFiles/DataFilesListing/DataFilesListing.js
@@ -26,7 +26,7 @@ const DataFilesListing = ({ api, scheme, system, path }) => {
   );
 
   const showViewPath = useSelector(
-    state => state.workbench && state.workbench.config.viewPath
+    state => api === 'tapis' && state.workbench && state.workbench.config.viewPath
   );
 
   const scrollBottomCallback = useCallback(() => {

--- a/client/src/components/DataFiles/DataFilesListing/DataFilesListing.js
+++ b/client/src/components/DataFiles/DataFilesListing/DataFilesListing.js
@@ -26,7 +26,8 @@ const DataFilesListing = ({ api, scheme, system, path }) => {
   );
 
   const showViewPath = useSelector(
-    state => api === 'tapis' && state.workbench && state.workbench.config.viewPath
+    state =>
+      api === 'tapis' && state.workbench && state.workbench.config.viewPath
   );
 
   const scrollBottomCallback = useCallback(() => {


### PR DESCRIPTION
## Overview: ##

Prevents View Path column from showing up in Google Drive (and other non-tapis) Data Files views.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [FP-815](https://jira.tacc.utexas.edu/browse/FP-815)

## Summary of Changes: ##

Add check that allows View Path to only show up for tapis API data files views

## Testing Steps: ##
1. Link Google Drive
2. Verify that View Path column does not exist

## UI Photos:

## Notes: ##

Issues related to TextCopyField feedback will be addressed in https://jira.tacc.utexas.edu/browse/FP-817
Issues related to View Path splitting into two lines, as well as other data files columns, will be addressed in https://jira.tacc.utexas.edu/browse/FP-818