### PR TITLE
task/FP-817 - TextCopyField user feedback

### DIFF
--- a/client/.stylelintrc.js
+++ b/client/.stylelintrc.js
@@ -344,7 +344,7 @@ module.exports = {
     // Require a newline or disallow whitespace before the commas of value lists.
     // 'value-list-comma-newline-before': null,
     // Require a single space or disallow whitespace after the commas of value lists (Autofixable).
-    'value-list-comma-space-after': 'always',
+    // 'value-list-comma-space-after': 'always-single-line',
     // Require a single space or disallow whitespace before the commas of value lists (Autofixable).
     // 'value-list-comma-space-before': null,
     // Limit the number of adjacent empty lines within value lists (Autofixable).

--- a/client/src/components/_common/TextCopyField/TextCopyField.js
+++ b/client/src/components/_common/TextCopyField/TextCopyField.js
@@ -5,7 +5,7 @@ import { Button } from 'reactstrap';
 import Icon from '../Icon';
 import './TextCopyField.module.scss';
 
-const TextCopyFieldButton = ({ isEmpty }) => {
+const TextCopyField = ({ value, placeholder }) => {
   const transitionDuration = 0.15; // second(s)
   const stateDuration = 1; // second(s)
   const stateTimeout = transitionDuration + stateDuration; // second(s)
@@ -20,32 +20,6 @@ const TextCopyFieldButton = ({ isEmpty }) => {
       clearTimeout(timeout);
     }, stateTimeout * 1000);
   }, [isCopied, setIsCopied]);
-
-  return (
-    <Button
-      styleName={`copy-button ${isCopied ? 'is-copied' : ''}`}
-      // RFE: Avoid manual JS ↔ CSS sync of transition duration by using:
-      //      - `data-attribute` and `attr()` (pending browser support)
-      //      - PostCSS and JSON variables (pending greater need for this)
-      style={{ '--transition-duration': `${transitionDuration}s` }}
-      onClick={onCopy}
-      disabled={isEmpty}
-      type="button"
-    >
-      <Icon
-        name={isCopied ? 'approved-reverse' : 'link'}
-        styleName="button__icon"
-      />
-      <span styleName="button__text">Copy</span>
-    </Button>
-  );
-};
-
-TextCopyFieldButton.propTypes = {
-  isEmpty: PropTypes.bool.isRequired
-};
-
-const TextCopyField = ({ value, placeholder }) => {
   const isEmpty = !value || value.length === 0;
   const onChange = event => {
     // Swallow keyboard events on the Input control, but
@@ -59,7 +33,22 @@ const TextCopyField = ({ value, placeholder }) => {
     <div className="input-group">
       <div className="input-group-prepend">
         <CopyToClipboard text={value}>
-          <TextCopyFieldButton isEmpty={isEmpty} />
+          <Button
+            styleName={`copy-button ${isCopied ? 'is-copied' : ''}`}
+            // RFE: Avoid manual JS ↔ CSS sync of transition duration by using:
+            //      - `data-attribute` and `attr()` (pending browser support)
+            //      - PostCSS and JSON variables (pending greater need for this)
+            style={{ '--transition-duration': `${transitionDuration}s` }}
+            onClick={onCopy}
+            disabled={isEmpty}
+            type="button"
+          >
+            <Icon
+              name={isCopied ? 'approved-reverse' : 'link'}
+              styleName="button__icon"
+            />
+            <span styleName="button__text">Copy</span>
+          </Button>
         </CopyToClipboard>
       </div>
       <input

--- a/client/src/components/_common/TextCopyField/TextCopyField.js
+++ b/client/src/components/_common/TextCopyField/TextCopyField.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 import PropTypes from 'prop-types';
 import { Button } from 'reactstrap';
@@ -6,6 +6,7 @@ import Icon from '../Icon';
 import './TextCopyField.module.scss';
 
 const TextCopyField = ({ value, placeholder }) => {
+  const wrapperRef = React.createRef();
   const onChange = event => {
     // Swallow keyboard events on the Input control, but
     // still allow selecting the text. readOnly property of
@@ -13,12 +14,21 @@ const TextCopyField = ({ value, placeholder }) => {
     // prevents text selection
     event.preventDefault();
   };
-  const onCopy = onChange;
+  
+  const onCopy = (event) => {
+    onChange(event);
+    const wrapper = wrapperRef.current;
+    wrapper.classList.toggle('copied');
+    setTimeout(() => {
+      console.log("Timeout");
+      wrapper.classList.toggle('copied')
+    }, 1000);
+  }
 
   const isEmpty = !value || value.length === 0;
 
   return (
-    <div className="input-group" styleName="root">
+    <div ref={wrapperRef} className="input-group" styleName="root">
       <div className="input-group-prepend">
         <CopyToClipboard text={value}>
           <Button

--- a/client/src/components/_common/TextCopyField/TextCopyField.js
+++ b/client/src/components/_common/TextCopyField/TextCopyField.js
@@ -1,12 +1,41 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 import PropTypes from 'prop-types';
 import { Button } from 'reactstrap';
 import Icon from '../Icon';
 import './TextCopyField.module.scss';
 
+const TextCopyFieldButton = ({ isEmpty }) => {
+  const [style, setStyle] = useState('copy-button');
+  const onCopy = useCallback(
+    event => {
+      event.preventDefault();
+      setStyle('copy-button copied');
+      setTimeout(() => {
+        setStyle('copy-button');
+      }, 2000);
+    },
+    [style, setStyle]
+  );
+
+  return (
+    <Button
+      styleName={style}
+      onClick={event => onCopy(event)}
+      disabled={isEmpty}
+    >
+      <Icon name="link" styleName="button__icon" />
+      <span styleName="button__text">Copy</span>
+    </Button>
+  );
+};
+
+TextCopyFieldButton.propTypes = {
+  isEmpty: PropTypes.bool.isRequired
+};
+
 const TextCopyField = ({ value, placeholder }) => {
-  const wrapperRef = React.createRef();
+  const isEmpty = !value || value.length === 0;
   const onChange = event => {
     // Swallow keyboard events on the Input control, but
     // still allow selecting the text. readOnly property of
@@ -14,31 +43,12 @@ const TextCopyField = ({ value, placeholder }) => {
     // prevents text selection
     event.preventDefault();
   };
-  
-  const onCopy = (event) => {
-    onChange(event);
-    const wrapper = wrapperRef.current;
-    wrapper.classList.toggle('copied');
-    setTimeout(() => {
-      console.log("Timeout");
-      wrapper.classList.toggle('copied')
-    }, 1000);
-  }
-
-  const isEmpty = !value || value.length === 0;
 
   return (
-    <div ref={wrapperRef} className="input-group" styleName="root">
+    <div className="input-group" styleName="root">
       <div className="input-group-prepend">
         <CopyToClipboard text={value}>
-          <Button
-            styleName="copy-button"
-            onClick={event => onCopy(event)}
-            disabled={isEmpty}
-          >
-            <Icon name="link" styleName="button__icon" />
-            <span styleName="button__text">Copy</span>
-          </Button>
+          <TextCopyFieldButton isEmpty={isEmpty} />
         </CopyToClipboard>
       </div>
       <input

--- a/client/src/components/_common/TextCopyField/TextCopyField.js
+++ b/client/src/components/_common/TextCopyField/TextCopyField.js
@@ -6,25 +6,36 @@ import Icon from '../Icon';
 import './TextCopyField.module.scss';
 
 const TextCopyFieldButton = ({ isEmpty }) => {
-  const [style, setStyle] = useState('copy-button');
-  const onCopy = useCallback(
-    event => {
-      event.preventDefault();
-      setStyle('copy-button copied');
-      setTimeout(() => {
-        setStyle('copy-button');
-      }, 2000);
-    },
-    [style, setStyle]
-  );
+  const transitionDuration = 0.15; // second(s)
+  const stateDuration = 1; // second(s)
+  const stateTimeout = transitionDuration + stateDuration; // second(s)
+
+  const [isCopied, setIsCopied] = useState(false);
+
+  const onCopy = useCallback(() => {
+    setIsCopied(true);
+
+    const timeout = setTimeout(() => {
+      setIsCopied(false);
+      clearTimeout(timeout);
+    }, stateTimeout * 1000);
+  }, [isCopied, setIsCopied]);
 
   return (
     <Button
-      styleName={style}
-      onClick={event => onCopy(event)}
+      styleName={`copy-button ${isCopied ? 'is-copied' : ''}`}
+      // RFE: Avoid manual JS ↔ CSS sync of transition duration by using:
+      //      - `data-attribute` and `attr()` (pending browser support)
+      //      - PostCSS and JSON variables (pending greater need for this)
+      style={{ '--transition-duration': `${transitionDuration}s` }}
+      onClick={onCopy}
       disabled={isEmpty}
+      type="button"
     >
-      <Icon name="link" styleName="button__icon" />
+      <Icon
+        name={isCopied ? 'approved-reverse' : 'link'}
+        styleName="button__icon"
+      />
       <span styleName="button__text">Copy</span>
     </Button>
   );
@@ -45,7 +56,7 @@ const TextCopyField = ({ value, placeholder }) => {
   };
 
   return (
-    <div className="input-group" styleName="root">
+    <div className="input-group">
       <div className="input-group-prepend">
         <CopyToClipboard text={value}>
           <TextCopyFieldButton isEmpty={isEmpty} />

--- a/client/src/components/_common/TextCopyField/TextCopyField.module.scss
+++ b/client/src/components/_common/TextCopyField/TextCopyField.module.scss
@@ -1,5 +1,14 @@
 .root {
   display: flex;
+  .copy-button {
+    transition: background-color 5s;
+  }
+}
+
+.root.copied {
+  .copy-button {
+    background-color: green;
+  }
 }
 
 .input {

--- a/client/src/components/_common/TextCopyField/TextCopyField.module.scss
+++ b/client/src/components/_common/TextCopyField/TextCopyField.module.scss
@@ -1,22 +1,33 @@
 .root {
   display: flex;
-  .copy-button {
-    transition: background-color 5s;
-  }
-}
-
-.root.copied {
-  .copy-button {
-    background-color: green;
-  }
 }
 
 .input {
   composes: form-control from '../../../styles/components/bootstrap.form.css';
 }
 
+@keyframes copied-anim {
+  0% {
+    background-color: green;
+    color: white;
+  }
+  80% {
+    background-color: green;
+    color: white;
+  }
+  100% {
+    background-color: #F4F4F4;
+    color: #484848;
+  }
+}
+
 .copy-button {
   composes: c-button--secondary from '../../../styles/components/c-button.css';
+}
+
+.copy-button.copied {
+  animation-name: copied-anim;
+  animation-duration: 2s;
 }
 
 .button__icon {

--- a/client/src/components/_common/TextCopyField/TextCopyField.module.scss
+++ b/client/src/components/_common/TextCopyField/TextCopyField.module.scss
@@ -1,33 +1,25 @@
-.root {
-  display: flex;
-}
-
 .input {
   composes: form-control from '../../../styles/components/bootstrap.form.css';
 }
 
-@keyframes copied-anim {
-  0% {
-    background-color: green;
-    color: white;
-  }
-  80% {
-    background-color: green;
-    color: white;
-  }
-  100% {
-    background-color: #F4F4F4;
-    color: #484848;
-  }
-}
-
 .copy-button {
+  // May be changed by JavaScript which also needs the value
+  --transition-duration: 0;
+
+  transition:
+    color var(--transition-duration),
+    background-color var(--transition-duration);
+
   composes: c-button--secondary from '../../../styles/components/c-button.css';
 }
 
-.copy-button.copied {
-  animation-name: copied-anim;
-  animation-duration: 2s;
+.copy-button.is-copied,
+// FAQ: The pseudo-classes allow override of Bootstrap styles/selectors
+.copy-button.is-copied:hover,
+.copy-button.is-copied:focus,
+.copy-button.is-copied:active {
+  background-color: var(--global-color-success--normal);
+  color: var(--global-color-primary--xx-light);
 }
 
 .button__icon {
@@ -37,4 +29,3 @@
 .button__text {
   /* … */
 }
-


### PR DESCRIPTION
## Overview: ##

TextCopyField now uses button style transitions to indicate text was copied

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [FP-817](https://jira.tacc.utexas.edu/browse/FP-817)

## Summary of Changes: ##

- TextCopyField javascript for state changes
- Transitions from @tacc-wbomar via https://github.com/TACC/Frontera-Portal/pull/310

## Testing Steps: ##
1. Create a link for a file
2. Use the copy button

## UI Photos:


https://user-images.githubusercontent.com/17181582/104609288-7fff3d80-5648-11eb-9df0-8c9513da0a3a.mov



## Notes: ##
