### PR TITLE
task/FP-825 - Fix HTML app loading

### DIFF
--- a/server/portal/apps/workspace/api/views.py
+++ b/server/portal/apps/workspace/api/views.py
@@ -467,6 +467,7 @@ class AppsTrayView(BaseApiView):
                             "id": app.htmlId,
                             "label": app.label,
                             "shortDescription": app.shortDescription,
+                            "appType": "html"
                         }
                     elif str(app.appType).lower() == 'agave':
                         # If this is an agave app, retrieve the definition


### PR DESCRIPTION
## Overview: ##

Fixed HTML app loading

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [FP-825](https://jira.tacc.utexas.edu/browse/FP-825)

## Summary of Changes: ##

Add "appType" field to HTML app definition response from backend

## Testing Steps: ##
1. In your container, make a categories.json fixture:

```
[{"model": "workspace.apptraycategory", "pk": 1, "fields": {"category": "Data Processing", "priority": 0}}, {"model": "workspace.apptraycategory", "pk": 2, "fields": {"category": "Simulation", "priority": 0}}, {"model": "workspace.apptraycategory", "pk": 3, "fields": {"category": "Visualization", "priority": 0}}]
```

2. In your container, make an apps.json fixture with the viz portal HTML app:
```
[{"model": "workspace.apptrayentry", "pk": 5, "fields": {"name": "", "label": "TACC Visualization Portal", "icon": "", "version": "1.0", "revision": "", "appId": "", "lastRetrieved": "", "appType": "html", "html": "<div class=\"jumbotron text-center\"> <h2>TACC Visualization Portal</h2> <p> The TACC Visualization Portal allows simple access to TACC's vis resources, including remote, interactive web-based access to Stampede2, Frontera, and Wrangler. Launch iPython, Jupyter, and R Studio sessions and more.</p><p><a class=\"btn btn-lg btn-primary\" href=\"https://vis.tacc.utexas.edu/\" target=\"_blank\">Launch</a></p></div>", "htmlId": "vis-portal", "available": true, "shortDescription": "TACC Visualization Portal", "category": 3}}]
```
3. Add the following category fixtures using these manage.py commands:

```
python manage.py loaddata categories.json
python manage.py loaddata apps.json
```

## UI Photos:

## Notes: ##

The response for HTML app definitions was missing a field "appType". I chose to solve this by adding it to the definition for HTML apps, though it is not part of the definition for agave apps. I could add this to those definitions, but I felt it was safer to keep the app definition close to what agave returns. Alternatively, I could have changed the check for "appType" in a definition to be a check for the presence of an "html" key, but I was worried that future agave definitions may have this key as well.