### PR TITLE
bug/FP-823 Project add user list shows all users, project creation failure persists

### DIFF
--- a/client/src/components/DataFiles/DataFilesProjectFileListing/DataFilesProjectFileListing.js
+++ b/client/src/components/DataFiles/DataFilesProjectFileListing/DataFilesProjectFileListing.js
@@ -26,6 +26,9 @@ const DataFilesProjectFileListing = ({ system, path }) => {
 
   const onManage = () => {
     dispatch({
+      type: 'USERS_CLEAR_SEARCH'
+    });
+    dispatch({
       type: 'DATA_FILES_TOGGLE_MODAL',
       payload: { operation: 'manageproject', props: {} }
     });

--- a/client/src/components/DataFiles/DataFilesProjectMembers/DataFilesProjectMembers.js
+++ b/client/src/components/DataFiles/DataFilesProjectMembers/DataFilesProjectMembers.js
@@ -29,6 +29,7 @@ const DataFilesProjectMembers = ({
   /* eslint-enable */
 
   const userSearch = e => {
+    if (!e.target.value || e.target.value.trim().length < 1) return;
     // Try to set the selectedUser to something matching current search results
     setSelectedUser(
       userSearchResults.find(user => formatUser(user) === e.target.value)

--- a/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.js
+++ b/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.js
@@ -40,6 +40,12 @@ const DataFilesSidebar = ({ readOnly }) => {
 
   const toggleAddProjectModal = () => {
     dispatch({
+      type: 'USERS_CLEAR_SEARCH'
+    });
+    dispatch({
+      type: 'PROJECTS_CLEAR_OPERATION'
+    });
+    dispatch({
       type: 'PROJECTS_MEMBER_LIST_SET',
       payload: [{ user, access: 'owner' }]
     });

--- a/client/src/redux/reducers/projects.reducers.js
+++ b/client/src/redux/reducers/projects.reducers.js
@@ -227,6 +227,11 @@ export default function projects(state = initialState, action) {
           result: null
         }
       };
+    case 'PROJECTS_CLEAR_OPERATION':
+      return {
+        ...state,
+        operation: initialState.operation
+      };
     default:
       return state;
   }

--- a/client/src/redux/reducers/users.reducers.js
+++ b/client/src/redux/reducers/users.reducers.js
@@ -35,6 +35,11 @@ export function users(state = initialState, action) {
           error: null
         }
       };
+    case 'USERS_CLEAR_SEARCH':
+      return {
+        ...state,
+        ...initialState
+      };
     default:
       return state;
   }


### PR DESCRIPTION
## Overview: ##

Fixes the following:

Frank: Selecting "Add user" but not filling in any characters seems to pull a list of everyone on the Frontera portal – or at least a list of people from a lot of different institutions.

Owais: If you're unable to create a workspace, the error message persists after closing the modal and then re-opening it

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [FP-823](https://jira.tacc.utexas.edu/browse/FP-823)

## Summary of Changes: ##

- Added reducers and dispatches to clear stale user search data and stale project operation data when loading manage team and Add Shared Workspace modals

## Testing Steps: ##
1. Force an error on project creation - this is easiest done  in the shell by:

```
from portal.apps.projects.models import ProjectId
ProjectId.objects.all().delete()
```

2. Try to Add a Shared Workspace - this will fail and an error message will appear.
3. Close the modal, re-open it. The error message will be gone.
4. Restore your ProjectId model in the shell:

```
ProjectId.object.create(value=30).save()
```
5. Log in with a few users to your local dev environment to populate the user list. (The ctaccxx accounts work.)
6. In the Manage Team modal, type a space into the Add User input field. Nothing should be returned
7. Search for a user with a few letters and see the list populate.
8. Close the modal
9. Reopen the Manage Team modal. The results should have cleared.

## UI Photos:

## Notes: ##
