### PR TITLE
bug/FP-831: Allow multiple <dd> elements when data is Array in DescriptionList

### DIFF
--- a/client/src/components/_common/DescriptionList/DescriptionList.js
+++ b/client/src/components/_common/DescriptionList/DescriptionList.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { v4 as uuidv4 } from 'uuid';
 
 import './DescriptionList.module.scss';
 
@@ -29,14 +30,22 @@ const DescriptionList = ({ className, data, density, direction }) => {
       className={className}
       data-testid="list"
     >
-      {Object.keys(data).map(key => (
+      {Object.entries(data).map(([key, value]) => (
         <React.Fragment key={key}>
           <dt styleName="key" data-testid="key">
             {key}
           </dt>
-          <dd styleName="value" data-testid="value">
-            {data[key]}
-          </dd>
+          {Array.isArray(value) ? (
+            value.map(val => (
+              <dd styleName="value" data-testid="value" key={uuidv4()}>
+                {val}
+              </dd>
+            ))
+          ) : (
+            <dd styleName="value" data-testid="value">
+              {value}
+            </dd>
+          )}
         </React.Fragment>
       ))}
     </dl>

--- a/client/src/components/_common/DescriptionList/DescriptionList.test.js
+++ b/client/src/components/_common/DescriptionList/DescriptionList.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import DescriptionList, * as DL from './DescriptionList';
+import renderComponent from 'utils/testing';
 
 const DATA = {
   Username: 'bobward500',
@@ -37,5 +38,21 @@ describe('Description List', () => {
     const className = DL.DENSITY_CLASS_MAP[density || DL.DEFAULT_DENSITY];
     expect(list).toBeDefined();
     expect(list.className).toMatch(className);
+  });
+
+  it('renders multiple <dd> terms when value is an Array', async () => {
+    const dataWithArray = {
+      Hobbits: [
+        'Frodo Baggins',
+        'Samwise Gamgee',
+        'Meriadoc Brandybuck',
+        'Peregrin'
+      ]
+    }
+    const { findAllByTestId } = render(<DescriptionList data={dataWithArray} />);
+    const keys = await findAllByTestId('key');
+    const values = await findAllByTestId('value');
+    expect(keys.length).toEqual(1)
+    expect(values.length).toEqual(4)
   });
 });

--- a/client/src/components/_common/DescriptionList/DescriptionList.test.js
+++ b/client/src/components/_common/DescriptionList/DescriptionList.test.js
@@ -46,7 +46,7 @@ describe('Description List', () => {
         'Frodo Baggins',
         'Samwise Gamgee',
         'Meriadoc Brandybuck',
-        'Peregrin'
+        'Peregrin Took'
       ]
     }
     const { findAllByTestId } = render(<DescriptionList data={dataWithArray} />);


### PR DESCRIPTION
## Overview: ##
An array is currently incorrectly rendering as a concatenated single `<dd>` element, rather than multiple stacked `<dd>` elements. This allows for multiple `<dd>` elements when value data is an Array.

## Related Jira tickets: ##

* [FP-831](https://jira.tacc.utexas.edu/browse/FP-831)

## Testing Steps: ##
1. Run a job with multiple inputs, like compress or zippy
2. View the job detail modal in History
3. Confirm data displays correctly as multiple value elements under the key

## UI Photos:

Before:
<img width="577" alt="Screen Shot 2021-01-07 at 12 55 46 PM" src="https://user-images.githubusercontent.com/20326896/103932605-b63c3a80-50e7-11eb-9c9c-12e2f2582a76.png">

After:
<img width="574" alt="Screen Shot 2021-01-07 at 12 54 40 PM" src="https://user-images.githubusercontent.com/20326896/103932621-bb998500-50e7-11eb-8f1e-15dc7bc45def.png">

