### PR TITLE
Quick: Remove DataFilesProjectMembers Unused Code

### DIFF
--- a/client/src/components/DataFiles/DataFilesProjectMembers/DataFilesProjectMembers.js
+++ b/client/src/components/DataFiles/DataFilesProjectMembers/DataFilesProjectMembers.js
@@ -87,7 +87,6 @@ const DataFilesProjectMembers = ({
         ''
       ),
       accessor: 'username',
-      headerClassName: 'project-members__loading-header',
       className: 'project-members__cell',
       Cell: el => (
         <>
@@ -128,7 +127,6 @@ const DataFilesProjectMembers = ({
         ''
       ),
       accessor: 'username',
-      headerClassName: 'project-members__loading-header',
       className: 'project-members__cell',
       Cell: el =>
         mode === 'transfer' && el.row.original === transferUser ? (

--- a/client/src/components/DataFiles/DataFilesProjectMembers/DataFilesProjectMembers.scss
+++ b/client/src/components/DataFiles/DataFilesProjectMembers/DataFilesProjectMembers.scss
@@ -9,8 +9,3 @@
   align-items: center;
   font-size: 12px;
 }
-
-.project-members__loading-header {
-  display: flex;
-  justify-content: flex-end;
-}


### PR DESCRIPTION
## Overview: ##

Remove unused code in `DataFilesProjectMembers`.

## Related Jira tickets: ##

* N/A. This revisits code from PR #275 (which is for [FP-213](https://jira.tacc.utexas.edu/browse/FP-213)).

## Summary of Changes: ##

- __Fix__: Remove `headerClassName` property, and the class it adds.
    - The class `project-members__loading-header` is never rendered (not even if `loading` prop is set to `true`).
    - The property `headerClassName` is a property in React table 6, but __not__ React Table 7.

## Testing Steps: ##

### Prerequisites

- Have access to a shared workspace that you can manage. You may create your own. See PR #275 for instructions.
- In code, change https://github.com/TACC/Frontera-Portal/blob/fb44b5fd7edd352556051e71620f79b49a275951/client/src/components/DataFiles/DataFilesModals/DataFilesManageProjectModal.js#L113 to `loading={true}`.

### Steps

0. Checkout the branch of this PR.
1. Navigate to "Data Files" section.
2. Load "Shared Workspaces".
3. Open a Shared Workspace.
4. Click the Manage Team action.
5. Review the loading spinner UI and live markup.
6. Do the same one the `master` branch.

#### Expected Result

Both UIs and markup look identical, specifically the table heading cell with the loading spinner.

## UI Photos:

![Shared Workspace - Manage Team - Loading Header UI](https://user-images.githubusercontent.com/62723358/104065513-79df0c00-51c5-11eb-80ca-5193b439cb54.png)
![Shared Workspace - Manage Team - Loading Header Markup](https://user-images.githubusercontent.com/62723358/104065509-78addf00-51c5-11eb-95d1-440395517793.png)

## Notes: ##
