### PR TITLE
task/FP-838: allow git tags as docker image tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ DOCKER_IMAGE_BRANCH := $(DOCKERHUB_REPO):$(shell git describe --exact-match --ta
 .PHONY: build
 build:
 	docker-compose -f ./server/conf/docker/docker-compose.yml build
-	docker tag $(DOCKER_IMAGE) $(DOCKER_IMAGE_LOCAL)
 
 .PHONY: build-full
 build-full:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@ DOCKERHUB_REPO := taccwma/$(shell cat ./docker_repo.var)
 DOCKER_TAG ?= $(shell git rev-parse --short HEAD)
 DOCKER_IMAGE := $(DOCKERHUB_REPO):$(DOCKER_TAG)
 DOCKER_IMAGE_LATEST := $(DOCKERHUB_REPO):latest
-DOCKER_IMAGE_LOCAL := $(DOCKERHUB_REPO):local
 
 ####
 # `DOCKER_IMAGE_BRANCH` tag is the git tag for the commit if it exists, else the branch on which the commit exists

--- a/Makefile
+++ b/Makefile
@@ -35,5 +35,5 @@ stop:
 	docker-compose -f server/conf/docker/docker-compose-dev.all.debug.yml down
 
 .PHONY: stop-full
-stop-full:
+stop-v:
 	docker-compose -f server/conf/docker/docker-compose-dev.all.debug.yml down -v

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
 DOCKERHUB_REPO := taccwma/$(shell cat ./docker_repo.var)
 DOCKER_TAG ?= $(shell git rev-parse --short HEAD)
 DOCKER_IMAGE := $(DOCKERHUB_REPO):$(DOCKER_TAG)
-DOCKER_IMAGE_BRANCH := $(DOCKERHUB_REPO):$(shell git symbolic-ref --short HEAD)
 DOCKER_IMAGE_LATEST := $(DOCKERHUB_REPO):latest
 DOCKER_IMAGE_LOCAL := $(DOCKERHUB_REPO):local
+
+####
+# `DOCKER_IMAGE_BRANCH` tag is the git tag for the commit if it exists, else the branch on which the commit exists
+DOCKER_IMAGE_BRANCH := $(DOCKERHUB_REPO):$(shell git describe --exact-match --tags 2> /dev/null || git symbolic-ref --short HEAD)
 
 .PHONY: build
 build:
@@ -32,3 +35,7 @@ start:
 .PHONY: stop
 stop:
 	docker-compose -f server/conf/docker/docker-compose-dev.all.debug.yml down
+
+.PHONY: stop-full
+stop-full:
+	docker-compose -f server/conf/docker/docker-compose-dev.all.debug.yml down -v


### PR DESCRIPTION
## Overview: ##

Allows automation of using git tags, such as a release tag (`v1.0.0`), as the docker image tag. If the commit being built does not have a tag, the branch name is used as the tag.

This will come in handy when using camino v2, as we can anticipate the docker image tag when making the release for the portal.

## Related Jira tickets: ##

* [FP-838](https://jira.tacc.utexas.edu/browse/FP-838)

