### PR TITLE
bug/FP-835 - ticket create modal UI fixes

### DIFF
--- a/client/src/components/Tickets/TicketCreateForm.js
+++ b/client/src/components/Tickets/TicketCreateForm.js
@@ -211,6 +211,7 @@ function TicketCreateForm({
                     size="sm"
                     color="white"
                     data-testid="creating-spinner"
+                    className="ticket-create-spinner"
                   />
                 )}
                 Add Ticket

--- a/client/src/components/Tickets/TicketCreateForm.js
+++ b/client/src/components/Tickets/TicketCreateForm.js
@@ -47,7 +47,7 @@ function CreatedTicketInformation({ provideDashBoardLinkOnSuccess, ticketId }) {
 
   if (provideDashBoardLinkOnSuccess) {
     return (
-      <Alert color="success">
+      <Alert color="success" className="ticket-create-info-alert">
         <Link
           className="ticket-link"
           to={`${ROUTES.WORKBENCH}${ROUTES.DASHBOARD}${ROUTES.TICKETS}/${ticketId}`}
@@ -59,7 +59,7 @@ function CreatedTicketInformation({ provideDashBoardLinkOnSuccess, ticketId }) {
     );
   }
   return (
-    <Alert color="success">
+    <Alert color="success" className="ticket-creation-info-alert">
       Ticket (#{ticketId}) was created. Support staff will contact you via email
       regarding your problem.
     </Alert>

--- a/client/src/components/Tickets/TicketCreateForm.scss
+++ b/client/src/components/Tickets/TicketCreateForm.scss
@@ -1,5 +1,4 @@
 .ticket-create-form {
-  height: 100%;
   display: flex;
   flex-direction: column;
   font-size: 0.75rem;

--- a/client/src/components/Tickets/TicketCreateForm.scss
+++ b/client/src/components/Tickets/TicketCreateForm.scss
@@ -30,6 +30,10 @@
   margin-right: 0.5em;
 }
 
+.ticket-create-info-alert {
+  margin-right: 1em;
+}
+
 .ticket-create-button-row .alert {
   margin-bottom: 0;
   border: none;

--- a/client/src/components/Tickets/TicketCreateForm.scss
+++ b/client/src/components/Tickets/TicketCreateForm.scss
@@ -27,6 +27,10 @@
   text-align: right;
 }
 
+.ticket-create-spinner {
+  margin-right: 0.5em;
+}
+
 .ticket-create-button-row .alert {
   margin-bottom: 0;
   border: none;

--- a/client/src/components/Tickets/TicketCreateModal.scss
+++ b/client/src/components/Tickets/TicketCreateModal.scss
@@ -2,6 +2,7 @@
   display: flex;
   flex-direction: column;
   overflow: auto;
+  padding-bottom: 1em;
 }
 
 .ticket-create-modal {


### PR DESCRIPTION
## Overview: ##

Addresses style issues with TicketCreateModal from December 1st, 2020 testing session

## Related Jira tickets: ##

* [FP-835](https://jira.tacc.utexas.edu/browse/FP-835)

## Summary of Changes: ##

- (minor) new ticket modal: no space beneath bottom of form and modal on short height modal - Wes (see Screenshots #1)
- (minor) new ticket modal: no space between button loading icon and button text- Wes (see Screenshots #2)
- Add ticket modal message when a ticket was successfully created looks kinda bad due to text/wrapping justification 
(see Screenshots #7)  - Nathan


## Testing Steps: ##
1. Shrink your window size
2. Submit a ticket

## UI Photos:

Spacing between loading icon and button text:

![image](https://user-images.githubusercontent.com/17181582/104240903-6da3ba80-5422-11eb-94e4-1d745e8acfa0.png)

Space between submit button and bottom of modal when modal is short

![image](https://user-images.githubusercontent.com/17181582/104343497-9e86fc80-54c1-11eb-883b-1b8664146766.png)

Space between ticket create information and submit button when modal is narrow

![image](https://user-images.githubusercontent.com/17181582/104344285-94b1c900-54c2-11eb-9160-e865e3156e16.png)

## Notes: ##
