### PR TITLE
bug/FP-841 - Add shared workspaces link in breadcdumbs, fix long titles in breadcrumbs

### DIFF
--- a/client/src/components/DataFiles/DataFiles.module.css
+++ b/client/src/components/DataFiles/DataFiles.module.css
@@ -24,7 +24,6 @@
   padding-bottom: 0.75rem; /* ~10px * design * 1.2 design-to-app ratio */
 
   display: flex;
-  flex-wrap: wrap; /* prevent breadcrumbs and action buttons from colliding */
   justify-content: space-between;
   align-items: flex-end;
 }

--- a/client/src/components/DataFiles/DataFilesBreadcrumbs/DataFilesBreadcrumbs.js
+++ b/client/src/components/DataFiles/DataFilesBreadcrumbs/DataFilesBreadcrumbs.js
@@ -113,6 +113,17 @@ const DataFilesBreadcrumbs = ({
 
   return (
     <div className={`breadcrumbs ${className}`}>
+      {scheme === 'projects' && (
+        <>
+          <Link
+            className="breadcrumb-link"
+            to={`/workbench/data/${api}/${scheme}/`}
+          >
+            Shared Workspaces
+          </Link>{' '}
+          /{' '}
+        </>
+      )}
       <BreadcrumbLink
         api={api}
         scheme={scheme}

--- a/client/src/components/DataFiles/DataFilesBreadcrumbs/DataFilesBreadcrumbs.scss
+++ b/client/src/components/DataFiles/DataFilesBreadcrumbs/DataFilesBreadcrumbs.scss
@@ -1,5 +1,6 @@
 .breadcrumbs {
   /* ... */
+  margin-right: 2em;
 }
 .breadcrumb-link {
   color: #9d85ef;


### PR DESCRIPTION
## Overview: ##

- Add Shared Workspaces breadcrumb link
- Fix long shared workspaces title pushing toolbar to new line

## Related Jira tickets: ##

* [FP-824](https://jira.tacc.utexas.edu/browse/FP-824)
* [FP-841](https://jira.tacc.utexas.edu/browse/FP-841)
* [FP-844](https://jira.tacc.utexas.edu/browse/FP-844)

## Summary of Changes: ##

## Testing Steps: ##
1. Make a long project title
2. Make sure it displays correctly
3. Make sure you can click the Shared WOrkspaces link and go back to shared workspaces listing

## UI Photos:

![image](https://user-images.githubusercontent.com/17181582/104353807-f166b100-54cd-11eb-9030-829516de4290.png)


## Notes: ##
