### PR TITLE
Task/fp 817 textcopyfield enhancements  polish

### DIFF
--- a/client/.stylelintrc.js
+++ b/client/.stylelintrc.js
@@ -344,7 +344,7 @@ module.exports = {
     // Require a newline or disallow whitespace before the commas of value lists.
     // 'value-list-comma-newline-before': null,
     // Require a single space or disallow whitespace after the commas of value lists (Autofixable).
-    'value-list-comma-space-after': 'always',
+    // 'value-list-comma-space-after': 'always-single-line',
     // Require a single space or disallow whitespace before the commas of value lists (Autofixable).
     // 'value-list-comma-space-before': null,
     // Limit the number of adjacent empty lines within value lists (Autofixable).

--- a/client/src/components/_common/TextCopyField/TextCopyField.js
+++ b/client/src/components/_common/TextCopyField/TextCopyField.js
@@ -11,26 +11,28 @@ const TextCopyFieldButton = ({ isEmpty }) => {
   const stateDuration = 1; // second(s)
   const stateTimeout = transitionDuration + stateDuration; // second(s)
 
-  const buttonStyleName = 'copy-button';
-  const [styleName, setStyleName] = useState(buttonStyleName);
+  const [isCopied, setIsCopied] = useState(false);
 
   const onCopy = useCallback(() => {
-    setStyleName(`${buttonStyleName} is-copied`);
+    setIsCopied(true);
 
     const timeout = setTimeout(() => {
-      setStyleName(buttonStyleName);
+      setIsCopied(false);
       clearTimeout(timeout);
     }, stateTimeout * 1000);
-  }, [styleName, setStyleName]);
+  }, [isCopied, setIsCopied]);
 
   return (
     <Button
-      styleName={styleName}
+      styleName={`copy-button ${isCopied ? 'is-copied' : ''}`}
       onClick={onCopy}
       disabled={isEmpty}
       type="button"
     >
-      <Icon name="link" styleName="button__icon" />
+      <Icon
+        name={isCopied ? 'approved-reverse' : 'link'}
+        styleName="button__icon"
+      />
       <span styleName="button__text">Copy</span>
     </Button>
   );

--- a/client/src/components/_common/TextCopyField/TextCopyField.js
+++ b/client/src/components/_common/TextCopyField/TextCopyField.js
@@ -6,7 +6,6 @@ import Icon from '../Icon';
 import './TextCopyField.module.scss';
 
 const TextCopyFieldButton = ({ isEmpty }) => {
-  // Must equal CSS `--transition-duration` value
   const transitionDuration = 0.15; // second(s)
   const stateDuration = 1; // second(s)
   const stateTimeout = transitionDuration + stateDuration; // second(s)
@@ -25,6 +24,10 @@ const TextCopyFieldButton = ({ isEmpty }) => {
   return (
     <Button
       styleName={`copy-button ${isCopied ? 'is-copied' : ''}`}
+      // RFE: Avoid manual JS ↔ CSS sync of transition duration by using:
+      //      - `data-attribute` and `attr()` (pending browser support)
+      //      - PostCSS and JSON variables (pending greater need for this)
+      style={{ '--transition-duration': `${transitionDuration}s` }}
       onClick={onCopy}
       disabled={isEmpty}
       type="button"

--- a/client/src/components/_common/TextCopyField/TextCopyField.js
+++ b/client/src/components/_common/TextCopyField/TextCopyField.js
@@ -6,23 +6,29 @@ import Icon from '../Icon';
 import './TextCopyField.module.scss';
 
 const TextCopyFieldButton = ({ isEmpty }) => {
-  const [style, setStyle] = useState('copy-button');
-  const onCopy = useCallback(
-    event => {
-      event.preventDefault();
-      setStyle('copy-button copied');
-      setTimeout(() => {
-        setStyle('copy-button');
-      }, 2000);
-    },
-    [style, setStyle]
-  );
+  // Must equal CSS `--transition-duration` value
+  const transitionDuration = 0.15; // second(s)
+  const stateDuration = 1; // second(s)
+  const stateTimeout = transitionDuration + stateDuration; // second(s)
+
+  const buttonStyleName = 'copy-button';
+  const [styleName, setStyleName] = useState(buttonStyleName);
+
+  const onCopy = useCallback(() => {
+    setStyleName(`${buttonStyleName} is-copied`);
+
+    const timeout = setTimeout(() => {
+      setStyleName(buttonStyleName);
+      clearTimeout(timeout);
+    }, stateTimeout * 1000);
+  }, [styleName, setStyleName]);
 
   return (
     <Button
-      styleName={style}
-      onClick={event => onCopy(event)}
+      styleName={styleName}
+      onClick={onCopy}
       disabled={isEmpty}
+      type="button"
     >
       <Icon name="link" styleName="button__icon" />
       <span styleName="button__text">Copy</span>
@@ -45,7 +51,7 @@ const TextCopyField = ({ value, placeholder }) => {
   };
 
   return (
-    <div className="input-group" styleName="root">
+    <div className="input-group">
       <div className="input-group-prepend">
         <CopyToClipboard text={value}>
           <TextCopyFieldButton isEmpty={isEmpty} />

--- a/client/src/components/_common/TextCopyField/TextCopyField.module.scss
+++ b/client/src/components/_common/TextCopyField/TextCopyField.module.scss
@@ -3,8 +3,8 @@
 }
 
 .copy-button {
-  // Must equal JS `transitionDuration` value
-  --transition-duration: 0.15s;
+  // May be changed by JavaScript which also needs the value
+  --transition-duration: 0;
 
   transition:
     color var(--transition-duration),

--- a/client/src/components/_common/TextCopyField/TextCopyField.module.scss
+++ b/client/src/components/_common/TextCopyField/TextCopyField.module.scss
@@ -1,33 +1,25 @@
-.root {
-  display: flex;
-}
-
 .input {
   composes: form-control from '../../../styles/components/bootstrap.form.css';
 }
 
-@keyframes copied-anim {
-  0% {
-    background-color: green;
-    color: white;
-  }
-  80% {
-    background-color: green;
-    color: white;
-  }
-  100% {
-    background-color: #F4F4F4;
-    color: #484848;
-  }
-}
-
 .copy-button {
+  // Must equal JS `transitionDuration` value
+  --transition-duration: 0.15s;
+
+  transition:
+    color var(--transition-duration),
+    background-color var(--transition-duration);
+
   composes: c-button--secondary from '../../../styles/components/c-button.css';
 }
 
-.copy-button.copied {
-  animation-name: copied-anim;
-  animation-duration: 2s;
+.copy-button.is-copied,
+// FAQ: The pseudo-classes allow override of Bootstrap styles/selectors
+.copy-button.is-copied:hover,
+.copy-button.is-copied:focus,
+.copy-button.is-copied:active {
+  background-color: green;
+  color: white;
 }
 
 .button__icon {
@@ -37,4 +29,3 @@
 .button__text {
   /* … */
 }
-

--- a/client/src/components/_common/TextCopyField/TextCopyField.module.scss
+++ b/client/src/components/_common/TextCopyField/TextCopyField.module.scss
@@ -18,8 +18,7 @@
 .copy-button.is-copied:hover,
 .copy-button.is-copied:focus,
 .copy-button.is-copied:active {
-  background-color: green;
-  color: white;
+  background-color: var(--global-color-success--normal);
 }
 
 .button__icon {

--- a/client/src/components/_common/TextCopyField/TextCopyField.module.scss
+++ b/client/src/components/_common/TextCopyField/TextCopyField.module.scss
@@ -19,6 +19,7 @@
 .copy-button.is-copied:focus,
 .copy-button.is-copied:active {
   background-color: var(--global-color-success--normal);
+  color: var(--global-color-primary--xx-light);
 }
 
 .button__icon {


### PR DESCRIPTION
## Overview: ##

Polish UI of PR #293.

## Related Jira tickets: ##

* [FP-817](https://jira.tacc.utexas.edu/browse/FP-817)

## Summary of Changes: ##

- _Minor_: Allow multi-line values in CSS.
- __New__: Separate class name from state logic.
- __Fix__: Configurable values for transition duration and state duration.
- _Minor_: Remove need for access to the actual click `event` (by using `type="button"`).
- __New__: Change icon on copy, and revert.
- _Minor_: Remove redundant `display: flex` (by removing `root` class name).
- __New__: Use CSS transition instead of CSS animation.
- __New__: Use CSS global variables for color.
- __Fix__: (Minutia) Prevent Bootstrap styles from breaking color change.

## Testing Steps: ##

### Functionality

1. See PR #293.

### UX Minutia

1. **Basic Test.** Click on Copy Link and move mouse away quickly.
    1. See immediate change of icon: 🔗  → ✔️ 
    1. See 0.15s transition from background _**light** gray_ to _green_ and color _**almost** black_ to _white_.
    1. See 1s of new colors and new icon.
    1. See immediate change of icon: ✔️  → 🔗 
    1. See 0.15s transition from background _green_ to _**light** gray_ and color _white_ to _**almost** black_.
1. **Delayed Activation.** Click _and hold_ on Copy Link, keep mouse still and release click, then _after color change_ move mouse away.
    1. See transition of colors and icon happen _only **after**_ releasing click.
    1. After remaining time of new colors and new icon, see 0.15s transition from background _green_ to _**light** gray_ […].
1. **Do Not Move Mouse.** Click _and hold_ on Copy Link, keep mouse still and release click (and continue to _keep mouse still_).
    1. See transition of colors and icon happen _only **after**_ releasing click.
    1. After remaining time of new colors and new icon, see 0.15s transition from background _green_ to _**medium** gray_ […].

## UI Photos:

https://user-images.githubusercontent.com/62723358/104382579-f8081f00-54f3-11eb-8094-0eeef85f7803.mov

## Notes: ##
