### PR TITLE
bug/FP-850 - Disable make link on community and public data

### DIFF
--- a/client/src/components/DataFiles/DataFilesToolbar/DataFilesToolbar.js
+++ b/client/src/components/DataFiles/DataFilesToolbar/DataFilesToolbar.js
@@ -40,7 +40,10 @@ const DataFilesToolbar = ({ scheme, api }) => {
 
   const showMakeLink = useSelector(
     state =>
-      state.workbench && state.workbench.config.makeLink && api === 'tapis'
+      state.workbench &&
+      state.workbench.config.makeLink &&
+      api === 'tapis' &&
+      (scheme === 'private' || scheme === 'projects')
   );
 
   const toggleRenameModal = () =>


### PR DESCRIPTION
## Overview: ##

Disables Create Link functionality for non-private systems

## Related Jira tickets: ##

* [FP-850](https://jira.tacc.utexas.edu/browse/FP-850)
* [FP-856](https://jira.tacc.utexas.edu/browse/FP-856)

## Summary of Changes: ##

- Restrict View Link to private and projects schemes

## Testing Steps: ##
1. Browse to My Data and make sure View Link is there
2. Browse to Community Data and make sure View Link is not there

## UI Photos:

![image](https://user-images.githubusercontent.com/17181582/104751924-9fb36600-571b-11eb-8c10-f7e0903cd525.png)

## Notes: ##

An outstanding issue was identified. Currently, any user on a Shared Workspace may create links. This creates a potential situation where a user could be removed, invalidating created links.

[FP-856](https://jira.tacc.utexas.edu/browse/FP-856)
