### PR TITLE
Handle error during data files scrolling

### DIFF
--- a/client/src/redux/reducers/datafiles.reducers.js
+++ b/client/src/redux/reducers/datafiles.reducers.js
@@ -242,7 +242,7 @@ export function files(state = initialFilesState, action) {
         ...state,
         loading: { ...state.loading, [action.payload.section]: false },
         error: { ...state.error, [action.payload.section]: true },
-        listing: { ...state.posts, [action.payload.section]: [] }
+        listing: { ...state.listing, [action.payload.section]: [] }
       };
 
     // Cases for selecting files.

--- a/client/src/redux/sagas/datafiles.sagas.js
+++ b/client/src/redux/sagas/datafiles.sagas.js
@@ -212,26 +212,35 @@ export function* scrollFiles(action) {
     }
   });
 
-  const listingResponse = yield call(
-    fetchFilesUtil,
-    action.payload.api,
-    action.payload.scheme,
-    action.payload.system,
-    action.payload.path || '',
-    action.payload.offset,
-    action.payload.limit,
-    action.payload.queryString,
-    action.payload.nextPageToken
-  );
-  yield put({
-    type: 'SCROLL_FILES_SUCCESS',
-    payload: {
-      files: listingResponse.listing,
-      reachedEnd: listingResponse.reachedEnd,
-      nextPageToken: listingResponse.nextPageToken,
-      section: action.payload.section
-    }
-  });
+  try {
+    const listingResponse = yield call(
+      fetchFilesUtil,
+      action.payload.api,
+      action.payload.scheme,
+      action.payload.system,
+      action.payload.path || '',
+      action.payload.offset,
+      action.payload.limit,
+      action.payload.queryString,
+      action.payload.nextPageToken
+    );
+    yield put({
+      type: 'SCROLL_FILES_SUCCESS',
+      payload: {
+        files: listingResponse.listing,
+        reachedEnd: listingResponse.reachedEnd,
+        nextPageToken: listingResponse.nextPageToken,
+        section: action.payload.section
+      }
+    });
+  } catch (e) {
+    yield put({
+      type: 'SCROLL_FILES_ERR',
+      payload: {
+        section: action.payload.section
+      }
+    });
+  }
 }
 
 export async function renameFileUtil(api, scheme, system, path, newName) {

--- a/client/src/redux/sagas/datafiles.sagas.test.js
+++ b/client/src/redux/sagas/datafiles.sagas.test.js
@@ -256,8 +256,50 @@ describe('scrollFiles', () => {
       })
       .run();
   });
+  it('runs scrollFiles saga with error', () => {
+    return expectSaga(scrollFiles, {
+      payload: {
+        section: 'FilesListing',
+        api: 'tapis',
+        scheme: 'private',
+        system: 'test.system',
+        path: 'path/to/file',
+        offset: 0,
+        limit: 100
+      }
+    })
+      .provide([
+        [
+          matchers.call.fn(fetchFilesUtil),
+          throwError("Failed!")
+        ]
+      ])
+      .put({
+        type: 'SCROLL_FILES_START',
+        payload: {
+          section: 'FilesListing'
+        }
+      })
+      .call(
+        fetchFilesUtil,
+        'tapis',
+        'private',
+        'test.system',
+        'path/to/file',
+        0,
+        100,
+        undefined,
+        undefined
+      )
+      .put({
+        type: 'SCROLL_FILES_ERR',
+        payload: {
+          section: 'FilesListing',
+        }
+      })
+      .run();
+  });
 });
-
 
 describe('copyFiles', () => {
   beforeEach(() => {


### PR DESCRIPTION
## Overview: ##

Handle possible errors during a data-files-scrolling request

## Related Jira tickets: ##

* [FP-803](https://jira.tacc.utexas.edu/browse/FP-803).  That ticket was created for the request causing an error which has already been fixed by @jarosenb .  This is just a follow up for handing any future errors.

## Summary of Changes: ##
* Handle possible errors during a data-files-scrolling request in saga
* Add saga unit test

## Testing Steps:
Add to `listing` in `server/portal/libs/agave/operations.py` (line ~36) to force error on scrolling.
```
if int(offset) > 1:
        raise ApiException("dummy")
```
Go to a directory containing enough files (>100) and scroll down to trigger a file listing request.  You should see the error message (in `master`, you would just see a spinner).
