### PR TITLE
bug/FP-653 - Add explicit mapping for Corral system name

### DIFF
--- a/client/src/utils/systems.js
+++ b/client/src/utils/systems.js
@@ -5,6 +5,13 @@
  * @return {string} system name
  */
 export function getSystemName(host) {
+  if (
+    host.startsWith('data.tacc') ||
+    host.startsWith('cloud.corral') ||
+    host.startsWith('secure.corral')
+  ) {
+    return 'Corral';
+  }
   const systemName = host.split('.')[0];
   return systemName.substring(0, 1).toUpperCase() + systemName.slice(1);
 }


### PR DESCRIPTION
## Overview: ##

Correctly map corral system names to Corral

## Related Jira tickets: ##

* [FP-653](https://jira.tacc.utexas.edu/browse/FP-653)

## Summary of Changes: ##

The Corral system name cannot be derived from the first part of the hostname. (data.tacc, cloud.corral, secure.corral.) This adds explicit mappings.

## Testing Steps: ##
1. Go to Allocations view
2. Select an allocation and user that has an allocation on Corral

## UI Photos:

![image](https://user-images.githubusercontent.com/17181582/105770990-8da8a300-5f25-11eb-8bfe-8b816fe7482f.png)


## Notes: ##
