### PR TITLE
bug/FP-867 - Fix JWT Auth

### DIFF
--- a/server/portal/utils/jwt_auth.py
+++ b/server/portal/utils/jwt_auth.py
@@ -86,7 +86,7 @@ def login_user_agave_jwt(request):
         user = None
 
     if user is not None:
-        user.backend = 'django.contrib.auth.backends.ModelBackend',
+        user.backend = 'django.contrib.auth.backends.ModelBackend'
         login(request, user)
 
         # Refresh agave oauth token


### PR DESCRIPTION
## Overview: ##

Remove a comma that was causing an error with JWT Auth. This is required for jupyter mounts.

## Related Jira tickets: ##

* [FP-867](https://jira.tacc.utexas.edu/browse/FP-867)

## Summary of Changes: ##

Remove a comma (probably a Django 2 compatibility problem)

## Testing Steps: ##
1. This code must be deployed to dev.cep.tacc.utexas.edu. Unfortunately, it is very difficult to test this locally since you need a signed JWT from agave.
2. Sign in to dev.cep.tacc.utexas.edu and make sure you can access community data
3. portal-mounts-staging and staging.jupyter.tacc.cloud are currently configured to ask dev.cep.tacc.utexas.edu for mounts
4. Log in to staging.jupyter.tacc.cloud and make sure you can see dev.cep's community data

## UI Photos:

## Notes: ##

This error was detected due to this exception occuring during jupyter mounts jwt authentication:

```
[DJANGO] ERROR 2021-01-26 16:46:55,824 UTC log django.request.log_response:228: Internal Server Error: /api/jupyter_mounts/
Traceback (most recent call last):
  File "/opt/pysetup/.venv/lib/python3.6/site-packages/django/core/handlers/exception.py", line 34, in inner
    response = get_response(request)
  File "/opt/pysetup/.venv/lib/python3.6/site-packages/django/core/handlers/base.py", line 115, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/opt/pysetup/.venv/lib/python3.6/site-packages/django/core/handlers/base.py", line 113, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/opt/pysetup/.venv/lib/python3.6/site-packages/django/views/generic/base.py", line 71, in view
    return self.dispatch(request, *args, **kwargs)
  File "/opt/pysetup/.venv/lib/python3.6/site-packages/django/utils/decorators.py", line 45, in _wrapper
    return bound_method(*args, **kwargs)
  File "./portal/utils/decorators.py", line 42, in decorated_function
    login_user_agave_jwt(request)
  File "./portal/utils/jwt_auth.py", line 90, in login_user_agave_jwt
    login(request, user)
  File "/opt/pysetup/.venv/lib/python3.6/site-packages/django/contrib/auth/__init__.py", line 124, in login
    raise TypeError('backend must be a dotted import path string (got %r).' % backend)
TypeError: backend must be a dotted import path string (got 'django.contrib.auth.backends.ModelBackend').
```

Confirmed that the error is likely due to the comma using the following python shell code:

```
>>> val = "string",
>>> type(val)
<class 'tuple'>
>>>
```
