### PR TITLE
bug/FP-868 - Set project ACLs for each member on creation

### DIFF
--- a/server/portal/apps/projects/views.py
+++ b/server/portal/apps/projects/views.py
@@ -112,15 +112,23 @@ class ProjectsApiView(BaseApiView):
         members = data['members']
         mgr = ProjectsManager(request.user)
         prj = mgr.create(title)
+        project_id = prj.project_id
         for member in members:
             try:
                 user = get_user_model().objects.get(username=member['username'])
                 if member['access'] == 'owner':
                     prj.add_pi(user)
+                    access = 'pi'
                 elif member['access'] == 'edit':
                     prj.add_co_pi(user)
+                    access = 'co_pi'
                 else:
                     raise ApiException("Unsupported access level")
+                mgr.add_member(
+                    project_id,
+                    access,
+                    member['username']
+                )
             except Exception:
                 LOGGER.exception(
                     "Project was created, but could not add {username}", username=member['username']

--- a/server/portal/apps/projects/views_unit_test.py
+++ b/server/portal/apps/projects/views_unit_test.py
@@ -46,7 +46,7 @@ def test_projects_search(regular_user, client, mock_project_mgr):
 
 
 def test_projects_post(authenticated_user, client, mock_project_mgr):
-    mock_project = MagicMock(storage={'name': 'PRJ-123'})
+    mock_project = MagicMock(storage={'name': 'PRJ-123'}, project_id='PRJ-123')
     mock_project_mgr.create.return_value = mock_project
 
     response = client.post(
@@ -65,6 +65,7 @@ def test_projects_post(authenticated_user, client, mock_project_mgr):
 
     mock_project_mgr.create.assert_called_with('Test Title')
     mock_project.add_pi.assert_called_with(authenticated_user)
+    mock_project_mgr.add_member.assert_called_with('PRJ-123', 'pi', 'username')
     assert response.status_code == 200
     assert response.json() == {
         'status': 200,


### PR DESCRIPTION
## Overview: ##

The Projects endpoint was not actually calling the ACLs app for each member on a new project. It was only adding them to the local metadata records. This fixes that

## Related Jira tickets: ##

* [FP-868](https://jira.tacc.utexas.edu/browse/FP-868)

## Summary of Changes: ##

- Call ProjectManager.add_member for each included member on a new project
- Unit tests

## Testing Steps: ##
1. Create a project with more than one member. You may have to use a test account
2. Log in to data.tacc.utexas.edu and locate your project folder
3. Check ACLs to make sure each member has been added to that folder. It may take a minute for the ACL app to run for every member
4. Try removing additional members to make sure the ACL app runs (optional)

## UI Photos:

## Notes: ##
