### PR TITLE
Task/FP-866 handle potential delay in systems list retrieval

### DIFF
--- a/client/src/components/Applications/AppForm/AppForm.js
+++ b/client/src/components/Applications/AppForm/AppForm.js
@@ -139,9 +139,9 @@ export const AppSchemaForm = ({ app }) => {
       portalAlloc: state.allocations.portal_alloc,
       jobSubmission: state.jobs.submit,
       hasDefaultAllocation: !state.allocations.loading
-        ? state.allocations.hosts[state.systems.defaultHost]
+        ? state.allocations.hosts[state.systems.datafiles.defaultHost]
         : true,
-      defaultHost: state.systems.defaultHost
+      defaultHost: state.systems.datafiles.defaultHost
     };
   }, shallowEqual);
 

--- a/client/src/components/Applications/AppForm/AppForm.js
+++ b/client/src/components/Applications/AppForm/AppForm.js
@@ -138,9 +138,10 @@ export const AppSchemaForm = ({ app }) => {
       allocations: matchingHost ? state.allocations.hosts[matchingHost] : [],
       portalAlloc: state.allocations.portal_alloc,
       jobSubmission: state.jobs.submit,
-      hasDefaultAllocation: !state.allocations.loading
-        ? state.allocations.hosts[state.systems.datafiles.defaultHost]
-        : true,
+      hasDefaultAllocation:
+        state.allocations.loading || state.systems.datafiles.loading
+          ? true
+          : state.allocations.hosts[state.systems.datafiles.defaultHost],
       defaultHost: state.systems.datafiles.defaultHost
     };
   }, shallowEqual);

--- a/client/src/components/Applications/AppForm/AppForm.js
+++ b/client/src/components/Applications/AppForm/AppForm.js
@@ -140,9 +140,9 @@ export const AppSchemaForm = ({ app }) => {
       jobSubmission: state.jobs.submit,
       hasDefaultAllocation:
         state.allocations.loading ||
-        state.systems.datafiles.loading ||
-        state.allocations.hosts[state.systems.datafiles.defaultHost],
-      defaultHost: state.systems.datafiles.defaultHost
+        state.systems.storage.loading ||
+        state.allocations.hosts[state.systems.storage.defaultHost],
+      defaultHost: state.systems.storage.defaultHost
     };
   }, shallowEqual);
 

--- a/client/src/components/Applications/AppForm/AppForm.js
+++ b/client/src/components/Applications/AppForm/AppForm.js
@@ -139,9 +139,9 @@ export const AppSchemaForm = ({ app }) => {
       portalAlloc: state.allocations.portal_alloc,
       jobSubmission: state.jobs.submit,
       hasDefaultAllocation:
-        state.allocations.loading || state.systems.datafiles.loading
-          ? true
-          : state.allocations.hosts[state.systems.datafiles.defaultHost],
+        state.allocations.loading ||
+        state.systems.datafiles.loading ||
+        state.allocations.hosts[state.systems.datafiles.defaultHost],
       defaultHost: state.systems.datafiles.defaultHost
     };
   }, shallowEqual);

--- a/client/src/components/Applications/AppForm/AppForm.test.js
+++ b/client/src/components/Applications/AppForm/AppForm.test.js
@@ -6,6 +6,7 @@ import { AppSchemaForm } from './AppForm';
 import { default as allocationsFixture } from './fixtures/AppForm.allocations.fixture';
 import { default as jobsFixture } from './fixtures/AppForm.jobs.fixture';
 import { default as namdFixture } from './fixtures/AppForm.app.fixture';
+import systemsFixture from '../../DataFiles/fixtures/DataFiles.systems.fixture';
 import '@testing-library/jest-dom/extend-expect';
 import { BrowserRouter } from 'react-router-dom';
 
@@ -13,10 +14,7 @@ const mockStore = configureStore();
 const initialMockState = {
   allocations: allocationsFixture,
   jobs: jobsFixture,
-  systems: {
-    defaultHost: 'frontera.tacc.utexas.edu',
-    systemsList: []
-  },
+  systems: systemsFixture,
   files: {
     listing: {
       modal: []

--- a/client/src/components/Applications/AppForm/AppForm.test.js
+++ b/client/src/components/Applications/AppForm/AppForm.test.js
@@ -14,7 +14,7 @@ const mockStore = configureStore();
 const initialMockState = {
   allocations: allocationsFixture,
   jobs: jobsFixture,
-  systems: systemsFixture,
+  systems: { ...systemsFixture, defaultHost: 'frontera.tacc.utexas.edu' },
   files: {
     listing: {
       modal: []

--- a/client/src/components/Applications/AppForm/AppForm.test.js
+++ b/client/src/components/Applications/AppForm/AppForm.test.js
@@ -14,7 +14,7 @@ const mockStore = configureStore();
 const initialMockState = {
   allocations: allocationsFixture,
   jobs: jobsFixture,
-  systems: { ...systemsFixture, defaultHost: 'frontera.tacc.utexas.edu' },
+  systems: systemsFixture,
   files: {
     listing: {
       modal: []

--- a/client/src/components/DataFiles/DataFiles.js
+++ b/client/src/components/DataFiles/DataFiles.js
@@ -11,6 +11,7 @@ import { parse } from 'query-string';
 
 import './DataFiles.module.css';
 
+import { Message, LoadingSpinner } from '_common';
 import DataFilesToolbar from './DataFilesToolbar/DataFilesToolbar';
 import DataFilesListing from './DataFilesListing/DataFilesListing';
 import DataFilesSidebar from './DataFilesSidebar/DataFilesSidebar';
@@ -95,10 +96,25 @@ const DataFiles = () => {
     state => state.files.params.FilesListing,
     shallowEqual
   );
+  const loading = useSelector(state => state.systems.datafiles.loading);
+  const error = useSelector(state => state.systems.datafiles.error);
 
   const readOnly =
     listingParams.scheme === 'projects' &&
     (listingParams.system === '' || !listingParams.system);
+
+  if (error) {
+    return (
+      <Message type="warn" styleName="error">
+        There was a problem retrieving your systems
+      </Message>
+    );
+  }
+
+  if (loading) {
+    return <LoadingSpinner />;
+  }
+
   return (
     <div styleName="container">
       {/* row containing breadcrumbs and toolbar */}

--- a/client/src/components/DataFiles/DataFiles.js
+++ b/client/src/components/DataFiles/DataFiles.js
@@ -11,7 +11,7 @@ import { parse } from 'query-string';
 
 import './DataFiles.module.css';
 
-import { Message, LoadingSpinner } from '_common';
+import { SectionMessage, LoadingSpinner } from '_common';
 import DataFilesToolbar from './DataFilesToolbar/DataFilesToolbar';
 import DataFilesListing from './DataFilesListing/DataFilesListing';
 import DataFilesSidebar from './DataFilesSidebar/DataFilesSidebar';
@@ -105,9 +105,11 @@ const DataFiles = () => {
 
   if (error) {
     return (
-      <Message type="warn" styleName="error">
-        There was a problem retrieving your systems
-      </Message>
+      <div styleName="error">
+        <SectionMessage type="warning">
+          There was a problem retrieving your systems
+        </SectionMessage>
+      </div>
     );
   }
 

--- a/client/src/components/DataFiles/DataFiles.js
+++ b/client/src/components/DataFiles/DataFiles.js
@@ -20,7 +20,10 @@ import DataFilesProjectsList from './DataFilesProjectsList/DataFilesProjectsList
 import DataFilesProjectFileListing from './DataFilesProjectFileListing/DataFilesProjectFileListing';
 
 const PrivateDataRedirect = () => {
-  const systems = useSelector(state => state.systems.systemList, shallowEqual);
+  const systems = useSelector(
+    state => state.systems.datafiles.list,
+    shallowEqual
+  );
   const history = useHistory();
   useEffect(() => {
     if (systems.length === 0) return;

--- a/client/src/components/DataFiles/DataFiles.js
+++ b/client/src/components/DataFiles/DataFiles.js
@@ -22,7 +22,7 @@ import DataFilesProjectFileListing from './DataFilesProjectFileListing/DataFiles
 
 const PrivateDataRedirect = () => {
   const systems = useSelector(
-    state => state.systems.datafiles.list,
+    state => state.systems.storage.configuration,
     shallowEqual
   );
   const history = useHistory();
@@ -96,8 +96,8 @@ const DataFiles = () => {
     state => state.files.params.FilesListing,
     shallowEqual
   );
-  const loading = useSelector(state => state.systems.datafiles.loading);
-  const error = useSelector(state => state.systems.datafiles.error);
+  const loading = useSelector(state => state.systems.storage.loading);
+  const error = useSelector(state => state.systems.storage.error);
 
   const readOnly =
     listingParams.scheme === 'projects' &&

--- a/client/src/components/DataFiles/DataFiles.module.css
+++ b/client/src/components/DataFiles/DataFiles.module.css
@@ -50,11 +50,8 @@
   display: flex;
 }
 
-/* Messaging */
+/* Error message */
 .error {
-  display: flex;
   justify-content: center;
   align-items: center;
-  color: #9d85ef;
-  padding: 30px;
 }

--- a/client/src/components/DataFiles/DataFiles.module.css
+++ b/client/src/components/DataFiles/DataFiles.module.css
@@ -52,6 +52,7 @@
 
 /* Error message */
 .error {
+  display: flex;
   justify-content: center;
   align-items: center;
 }

--- a/client/src/components/DataFiles/DataFiles.module.css
+++ b/client/src/components/DataFiles/DataFiles.module.css
@@ -49,3 +49,12 @@
   padding-left: 20px;
   display: flex;
 }
+
+/* Messaging */
+.error {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: #9d85ef;
+  padding: 30px;
+}

--- a/client/src/components/DataFiles/DataFilesBreadcrumbs/DataFilesBreadcrumbs.js
+++ b/client/src/components/DataFiles/DataFilesBreadcrumbs/DataFilesBreadcrumbs.js
@@ -82,7 +82,7 @@ const DataFilesBreadcrumbs = ({
 }) => {
   const paths = [];
   const pathComps = [];
-  const systemList = useSelector(state => state.systems.systemList);
+  const systemList = useSelector(state => state.systems.datafiles.list);
   const projectsList = useSelector(state => state.projects.listing.projects);
 
   path

--- a/client/src/components/DataFiles/DataFilesBreadcrumbs/DataFilesBreadcrumbs.js
+++ b/client/src/components/DataFiles/DataFilesBreadcrumbs/DataFilesBreadcrumbs.js
@@ -82,7 +82,7 @@ const DataFilesBreadcrumbs = ({
 }) => {
   const paths = [];
   const pathComps = [];
-  const systemList = useSelector(state => state.systems.datafiles.list);
+  const systemList = useSelector(state => state.systems.storage.configuration);
   const projectsList = useSelector(state => state.projects.listing.projects);
 
   path

--- a/client/src/components/DataFiles/DataFilesListing/DataFilesListing.test.js
+++ b/client/src/components/DataFiles/DataFilesListing/DataFilesListing.test.js
@@ -4,6 +4,7 @@ import  DataFilesListing  from "./DataFilesListing";
 import { CheckboxCell, FileNavCell } from "./DataFilesListingCells";
 import configureStore from "redux-mock-store";
 import renderComponent from 'utils/testing';
+import systemsFixture from '../fixtures/DataFiles.systems.fixture';
 
 const mockStore = configureStore();
 const initialMockState = {
@@ -39,9 +40,7 @@ const initialMockState = {
       FilesListing: true
     }
   },
-  systems: {
-    systemList: []
-  }
+  systems: systemsFixture
 };
 
 describe("CheckBoxCell", () => {

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesCopyModal.js
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesCopyModal.js
@@ -38,7 +38,10 @@ const DataFilesCopyModal = React.memo(() => {
     shallowEqual
   );
   const [disabled, setDisabled] = useState(false);
-  const systems = useSelector(state => state.systems.systemList, shallowEqual);
+  const systems = useSelector(
+    state => state.systems.datafiles.list,
+    shallowEqual
+  );
 
   const selectedFiles = useSelector(
     state =>

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesCopyModal.js
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesCopyModal.js
@@ -39,7 +39,7 @@ const DataFilesCopyModal = React.memo(() => {
   );
   const [disabled, setDisabled] = useState(false);
   const systems = useSelector(
-    state => state.systems.datafiles.list,
+    state => state.systems.storage.configuration,
     shallowEqual
   );
 

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesMkdirModal.js
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesMkdirModal.js
@@ -9,7 +9,7 @@ import { Button, Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
 
 const DataFilesMkdirModal = () => {
   const dispatch = useDispatch();
-  const systemList = useSelector(state => state.systems.datafiles.list);
+  const systemList = useSelector(state => state.systems.storage.configuration);
   const projectsList = useSelector(state => state.projects.listing.projects);
   const isOpen = useSelector(state => state.files.modals.mkdir);
   const params = useSelector(

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesMkdirModal.js
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesMkdirModal.js
@@ -9,7 +9,7 @@ import { Button, Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
 
 const DataFilesMkdirModal = () => {
   const dispatch = useDispatch();
-  const systemList = useSelector(state => state.systems.systemList);
+  const systemList = useSelector(state => state.systems.datafiles.list);
   const projectsList = useSelector(state => state.projects.listing.projects);
   const isOpen = useSelector(state => state.files.modals.mkdir);
   const params = useSelector(

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesModalTables/DataFilesModalListingTable.js
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesModalTables/DataFilesModalListingTable.js
@@ -157,7 +157,7 @@ const DataFilesModalListingTable = ({
   const loading = useSelector(state => state.files.loading.modal);
   const error = useSelector(state => state.files.error.modal);
   const params = useSelector(state => state.files.params.modal, shallowEqual);
-  const systemList = useSelector(state => state.systems.datafiles.list);
+  const systemList = useSelector(state => state.systems.storage.configuration);
   const isNotRoot = params.path.length > 0;
 
   const alteredData = useMemo(() => {

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesModalTables/DataFilesModalListingTable.js
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesModalTables/DataFilesModalListingTable.js
@@ -157,7 +157,7 @@ const DataFilesModalListingTable = ({
   const loading = useSelector(state => state.files.loading.modal);
   const error = useSelector(state => state.files.error.modal);
   const params = useSelector(state => state.files.params.modal, shallowEqual);
-  const systemList = useSelector(state => state.systems.systemList);
+  const systemList = useSelector(state => state.systems.datafiles.list);
   const isNotRoot = params.path.length > 0;
 
   const alteredData = useMemo(() => {

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesSelectModal.js
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesSelectModal.js
@@ -9,7 +9,7 @@ import DataFilesProjectsList from '../DataFilesProjectsList/DataFilesProjectsLis
 
 const DataFilesSelectModal = ({ isOpen, toggle, onSelect }) => {
   const systems = useSelector(
-    state => state.systems.datafiles.list,
+    state => state.systems.storage.configuration,
     shallowEqual
   );
   const files = useSelector(state => state.files.listing.modal, shallowEqual);

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesSelectModal.js
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesSelectModal.js
@@ -8,7 +8,10 @@ import DataFilesSystemSelector from '../DataFilesSystemSelector/DataFilesSystemS
 import DataFilesProjectsList from '../DataFilesProjectsList/DataFilesProjectsList';
 
 const DataFilesSelectModal = ({ isOpen, toggle, onSelect }) => {
-  const systems = useSelector(state => state.systems.systemList, shallowEqual);
+  const systems = useSelector(
+    state => state.systems.datafiles.list,
+    shallowEqual
+  );
   const files = useSelector(state => state.files.listing.modal, shallowEqual);
   const { showProjects } = useSelector(state => state.files.modalProps.select);
   const dispatch = useDispatch();

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesShowPathModal.js
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesShowPathModal.js
@@ -26,7 +26,7 @@ const DataFilesShowPathModal = React.memo(() => {
     if (!file) {
       return null;
     }
-    const matching = state.systems.definitions.find(
+    const matching = state.systems.definitions.list.find(
       sys => sys.id === file.system
     );
     return matching;

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesUploadModal.js
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesUploadModal.js
@@ -51,7 +51,7 @@ const DataFilesUploadModal = () => {
   const isOpen = useSelector(state => state.files.modals.upload);
   const params = useSelector(state => state.files.params.FilesListing);
   const status = useSelector(state => state.files.operationStatus.upload);
-  const systemList = useSelector(state => state.systems.systemList);
+  const systemList = useSelector(state => state.systems.datafiles.list);
   const projectsList = useSelector(state => state.projects.listing.projects);
   const [uploadedFiles, setUploadedFiles] = useState([]);
   const dispatch = useDispatch();

--- a/client/src/components/DataFiles/DataFilesModals/DataFilesUploadModal.js
+++ b/client/src/components/DataFiles/DataFilesModals/DataFilesUploadModal.js
@@ -51,7 +51,7 @@ const DataFilesUploadModal = () => {
   const isOpen = useSelector(state => state.files.modals.upload);
   const params = useSelector(state => state.files.params.FilesListing);
   const status = useSelector(state => state.files.operationStatus.upload);
-  const systemList = useSelector(state => state.systems.datafiles.list);
+  const systemList = useSelector(state => state.systems.storage.configuration);
   const projectsList = useSelector(state => state.projects.listing.projects);
   const [uploadedFiles, setUploadedFiles] = useState([]);
   const dispatch = useDispatch();

--- a/client/src/components/DataFiles/DataFilesSearchbar/DataFilesSearchbar.js
+++ b/client/src/components/DataFiles/DataFilesSearchbar/DataFilesSearchbar.js
@@ -15,7 +15,7 @@ const DataFilesSearchbar = ({ api, scheme, system, className }) => {
       state.files.loading.FilesListing === true ||
       state.files.error.FilesListing !== false
   );
-  const systemList = useSelector(state => state.systems.datafiles.list);
+  const systemList = useSelector(state => state.systems.storage.configuration);
   const [query, setQuery] = useState('');
   const history = useHistory();
   const hasQuery = queryString.parse(useLocation().search).query_string;

--- a/client/src/components/DataFiles/DataFilesSearchbar/DataFilesSearchbar.js
+++ b/client/src/components/DataFiles/DataFilesSearchbar/DataFilesSearchbar.js
@@ -15,7 +15,7 @@ const DataFilesSearchbar = ({ api, scheme, system, className }) => {
       state.files.loading.FilesListing === true ||
       state.files.error.FilesListing !== false
   );
-  const systemList = useSelector(state => state.systems.systemList);
+  const systemList = useSelector(state => state.systems.datafiles.list);
   const [query, setQuery] = useState('');
   const history = useHistory();
   const hasQuery = queryString.parse(useLocation().search).query_string;

--- a/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.js
+++ b/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.js
@@ -29,7 +29,7 @@ const DataFilesSidebar = ({ readOnly }) => {
   const err = useSelector(state => state.files.error.FilesListing);
   const { api, scheme } = useSelector(state => state.files.params.FilesListing);
   const systems = useSelector(
-    state => state.systems.datafiles.list,
+    state => state.systems.storage.configuration,
     shallowEqual
   );
   const { user } = useSelector(state => state.authenticatedUser);

--- a/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.js
+++ b/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.js
@@ -28,7 +28,10 @@ const DataFilesSidebar = ({ readOnly }) => {
   };
   const err = useSelector(state => state.files.error.FilesListing);
   const { api, scheme } = useSelector(state => state.files.params.FilesListing);
-  const systems = useSelector(state => state.systems.systemList, shallowEqual);
+  const systems = useSelector(
+    state => state.systems.datafiles.list,
+    shallowEqual
+  );
   const { user } = useSelector(state => state.authenticatedUser);
 
   const toggleMkdirModal = () => {

--- a/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.test.js
+++ b/client/src/components/DataFiles/DataFilesSidebar/DataFilesSidebar.test.js
@@ -1,37 +1,39 @@
 import React from 'react';
 import { Route } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
-import DataFilesSidebar from './DataFilesSidebar';
 import configureStore from 'redux-mock-store';
-import systemsFixture from '../fixtures/DataFiles.systems.fixture';
 import renderComponent from 'utils/testing';
+import DataFilesSidebar from './DataFilesSidebar';
+import systemsFixture from '../fixtures/DataFiles.systems.fixture';
 
 const mockStore = configureStore();
+
+const store = mockStore({
+  files: {
+    error: {
+      FilesListing: false
+    },
+    params: {
+      FilesListing: {}
+    }
+  },
+  systems: systemsFixture,
+  authenticatedUser: {
+    user: {
+      username: 'username',
+      first_name: 'User',
+      last_name: 'Name',
+      email: 'user@username.com'
+    }
+  }
+});
 
 describe('DataFilesSidebar', () => {
   it('contains an Add button and a link', () => {
     const history = createMemoryHistory();
     history.push('/workbench/data/');
-    const store = mockStore({
-      files: {
-        error: {
-          FilesListing: false
-        },
-        params: {
-          FilesListing: {}
-        }
-      },
-      systems: systemsFixture,
-      authenticatedUser: {
-        user: {
-          username: "username",
-          first_name: "User",
-          last_name: "Name",
-          email: "user@username.com"
-        }
-      }
-    });
-    const { getByText, debug } = renderComponent(
+
+    const { getByText } = renderComponent(
       <Route path="/workbench/data">
         <DataFilesSidebar />
       </Route>,
@@ -51,6 +53,6 @@ describe('DataFilesSidebar', () => {
       getByText(/My Data \(Longhorn\)/)
         .closest('a')
         .getAttribute('href')
-    ).toEqual('/workbench/data/tapis/private/longhorn.home.username/');    
+    ).toEqual('/workbench/data/tapis/private/longhorn.home.username/');
   });
 });

--- a/client/src/components/DataFiles/DataFilesSystemSelector/DataFilesSystemSelector.js
+++ b/client/src/components/DataFiles/DataFilesSystemSelector/DataFilesSystemSelector.js
@@ -13,7 +13,7 @@ const DataFilesSystemSelector = ({
   showProjects
 }) => {
   const dispatch = useDispatch();
-  const systemList = useSelector(state => state.systems.systemList);
+  const systemList = useSelector(state => state.systems.datafiles.list);
   const findSystem = id => systemList.find(system => system.system === id);
   const [selectedSystem, setSelectedSystem] = useState(systemId);
 

--- a/client/src/components/DataFiles/DataFilesSystemSelector/DataFilesSystemSelector.js
+++ b/client/src/components/DataFiles/DataFilesSystemSelector/DataFilesSystemSelector.js
@@ -13,7 +13,7 @@ const DataFilesSystemSelector = ({
   showProjects
 }) => {
   const dispatch = useDispatch();
-  const systemList = useSelector(state => state.systems.datafiles.list);
+  const systemList = useSelector(state => state.systems.storage.configuration);
   const findSystem = id => systemList.find(system => system.system === id);
   const [selectedSystem, setSelectedSystem] = useState(systemId);
 

--- a/client/src/components/DataFiles/fixtures/DataFiles.systems.fixture.js
+++ b/client/src/components/DataFiles/fixtures/DataFiles.systems.fixture.js
@@ -1,7 +1,7 @@
 const systemsFixture = {
-  datafiles: {
+  storage: {
     defaultHost: 'frontera.tacc.utexas.edu',
-    list: [
+    configuration: [
       {
         name: 'My Data (Frontera)',
         system: 'frontera.home.username',

--- a/client/src/components/DataFiles/fixtures/DataFiles.systems.fixture.js
+++ b/client/src/components/DataFiles/fixtures/DataFiles.systems.fixture.js
@@ -1,6 +1,6 @@
 const systemsFixture = {
-  defaultHost: 'frontera.tacc.utexas.edu',
   datafiles: {
+    defaultHost: 'frontera.tacc.utexas.edu',
     list: [
       {
         name: 'My Data (Frontera)',

--- a/client/src/components/DataFiles/fixtures/DataFiles.systems.fixture.js
+++ b/client/src/components/DataFiles/fixtures/DataFiles.systems.fixture.js
@@ -1,40 +1,50 @@
 const systemsFixture = {
   defaultHost: 'frontera.tacc.utexas.edu',
-  systemList: [
-    {
-      name: 'My Data (Frontera)',
-      system: 'frontera.home.username',
-      scheme: 'private',
-      api: 'tapis'
-    },
-    {
-      name: 'My Data (Longhorn)',
-      system: 'longhorn.home.username',
-      scheme: 'private',
-      api: 'tapis'
-    },
-    {
-      name: 'Shared Workspaces',
-      scheme: 'projects',
-      api: 'tapis'
-    }
-  ],
-  definitions: [
-    {
-      id: 'frontera.home.username',
-      storage: {
-        host: 'frontera.tacc.utexas.edu',
-        rootDir: '/home1/012345/username'
+  datafiles: {
+    list: [
+      {
+        name: 'My Data (Frontera)',
+        system: 'frontera.home.username',
+        scheme: 'private',
+        api: 'tapis'
+      },
+      {
+        name: 'My Data (Longhorn)',
+        system: 'longhorn.home.username',
+        scheme: 'private',
+        api: 'tapis'
+      },
+      {
+        name: 'Shared Workspaces',
+        scheme: 'projects',
+        api: 'tapis'
       }
-    },
-    {
-      id: 'longhorn.home.username',
-      storage: {
-        host: 'longhorn.tacc.utexas.edu',
-        rootDir: '/home/012345/username'
+    ],
+    error: false,
+    errorMessage: null,
+    loading: false
+  },
+  definitions: {
+    list: [
+      {
+        id: 'frontera.home.username',
+        storage: {
+          host: 'frontera.tacc.utexas.edu',
+          rootDir: '/home1/012345/username'
+        }
+      },
+      {
+        id: 'longhorn.home.username',
+        storage: {
+          host: 'longhorn.tacc.utexas.edu',
+          rootDir: '/home/012345/username'
+        }
       }
-    }
-  ]
+    ],
+    error: false,
+    errorMessage: null,
+    loading: true
+  }
 };
 
 export default systemsFixture;

--- a/client/src/components/PublicData/PublicData.js
+++ b/client/src/components/PublicData/PublicData.js
@@ -23,7 +23,9 @@ const PublicData = () => {
 
   const publicDataSystem = useSelector(
     state =>
-      state.systems.datafiles.list.find(sys => sys.scheme === 'public') || {}
+      state.systems.storage.configuration.find(
+        sys => sys.scheme === 'public'
+      ) || {}
   );
   const selectedFiles = useSelector(state =>
     state.files.selected.FilesListing.map(

--- a/client/src/components/PublicData/PublicData.js
+++ b/client/src/components/PublicData/PublicData.js
@@ -22,7 +22,8 @@ const PublicData = () => {
   const dispatch = useDispatch();
 
   const publicDataSystem = useSelector(
-    state => state.systems.systemList.find(sys => sys.scheme === 'public') || {}
+    state =>
+      state.systems.datafiles.list.find(sys => sys.scheme === 'public') || {}
   );
   const selectedFiles = useSelector(state =>
     state.files.selected.FilesListing.map(

--- a/client/src/components/PublicData/PublicData.test.js
+++ b/client/src/components/PublicData/PublicData.test.js
@@ -3,23 +3,26 @@ import { createMemoryHistory } from 'history';
 import configureStore from 'redux-mock-store';
 import PublicData from './PublicData';
 import filesFixture from '../DataFiles/fixtures/DataFiles.files.fixture';
+import systemsFixture from '../DataFiles/fixtures/DataFiles.systems.fixture';
 import renderComponent from 'utils/testing';
 
 const mockStore = configureStore();
 
-const systemsFixture = {
+const systems = {
+  ...systemsFixture,
   defaultHost: 'frontera.tacc.utexas.edu',
-  systemList: [
-    {
-      name: 'Public Data',
-      system: 'cep.storage.public',
-      scheme: 'public',
-      api: 'tapis',
-      icon: null
-    }
-  ],
-  error: false,
-  errorMessage: null
+  datafiles: {
+    ...systemsFixture.datafiles,
+    list: [
+      {
+        name: 'Public Data',
+        system: 'cep.storage.public',
+        scheme: 'public',
+        api: 'tapis',
+        icon: null
+      }
+    ]
+  }
 };
 
 describe('PublicData', () => {
@@ -27,7 +30,7 @@ describe('PublicData', () => {
     const history = createMemoryHistory();
     history.push('/public-data');
     const store = mockStore({
-      systems: systemsFixture,
+      systems,
       files: filesFixture,
       projects: {
         listing: {
@@ -36,12 +39,7 @@ describe('PublicData', () => {
       },
       pushKeys: { target: {} }
     });
-    console.log(filesFixture);
-    const { getByText, getAllByText, debug } = renderComponent(
-      <PublicData />,
-      store,
-      history
-    );
+    const { getByText } = renderComponent(<PublicData />, store, history);
 
     expect(getByText(/Public Data/)).toBeDefined();
     expect(history.location.pathname).toEqual(

--- a/client/src/components/PublicData/PublicData.test.js
+++ b/client/src/components/PublicData/PublicData.test.js
@@ -10,10 +10,9 @@ const mockStore = configureStore();
 
 const systems = {
   ...systemsFixture,
-  defaultHost: 'frontera.tacc.utexas.edu',
-  datafiles: {
-    ...systemsFixture.datafiles,
-    list: [
+  storage: {
+    ...systemsFixture.storage,
+    configuration: [
       {
         name: 'Public Data',
         system: 'cep.storage.public',

--- a/client/src/components/Toasts/Toast.js
+++ b/client/src/components/Toasts/Toast.js
@@ -74,7 +74,7 @@ const NotificationToast = () => {
 };
 
 const ToastMessage = ({ notification }) => {
-  const systemList = useSelector(state => state.systems.datafiles.list);
+  const systemList = useSelector(state => state.systems.storage.configuration);
   return (
     <>
       {notification && (

--- a/client/src/components/Toasts/Toast.js
+++ b/client/src/components/Toasts/Toast.js
@@ -74,7 +74,7 @@ const NotificationToast = () => {
 };
 
 const ToastMessage = ({ notification }) => {
-  const systemList = useSelector(state => state.systems.systemList);
+  const systemList = useSelector(state => state.systems.datafiles.list);
   return (
     <>
       {notification && (

--- a/client/src/redux/reducers/datafiles.reducers.js
+++ b/client/src/redux/reducers/datafiles.reducers.js
@@ -1,6 +1,6 @@
 export const initialSystemState = {
-  datafiles: {
-    list: [],
+  storage: {
+    configuration: [],
     error: false,
     errorMessage: null,
     loading: false,
@@ -26,8 +26,9 @@ export function systems(state = initialSystemState, action) {
     case 'FETCH_SYSTEMS_STARTED':
       return {
         ...state,
-        datafiles: {
-          ...state.datafiles,
+        storage: {
+          ...state.storage,
+          configuration: [],
           error: false,
           errorMessage: null,
           loading: true
@@ -36,9 +37,9 @@ export function systems(state = initialSystemState, action) {
     case 'FETCH_SYSTEMS_SUCCESS':
       return {
         ...state,
-        datafiles: {
-          ...state.datafiles,
-          list: action.payload.system_list,
+        storage: {
+          ...state.storage,
+          configuration: action.payload.system_list,
           defaultHost: action.payload.default_host,
           loading: false
         }
@@ -46,8 +47,8 @@ export function systems(state = initialSystemState, action) {
     case 'FETCH_SYSTEMS_ERROR':
       return {
         ...state,
-        datafiles: {
-          ...state.datafiles,
+        storage: {
+          ...state.storage,
           error: true,
           errorMessage: action.payload,
           loading: false
@@ -57,7 +58,7 @@ export function systems(state = initialSystemState, action) {
       return {
         ...state,
         definitions: {
-          ...state.datafiles,
+          ...state.definitions,
           error: false,
           errorMessage: null,
           loading: true
@@ -67,7 +68,7 @@ export function systems(state = initialSystemState, action) {
       return {
         ...state,
         definitions: {
-          ...state.datafiles,
+          ...state.definitions,
           list: addSystemDefinition(action.payload, state.definitions),
           error: false,
           errorMessage: null,

--- a/client/src/redux/reducers/datafiles.reducers.js
+++ b/client/src/redux/reducers/datafiles.reducers.js
@@ -1,10 +1,17 @@
 export const initialSystemState = {
-  defaultHost: '',
-  systemList: [],
-  error: false,
-  errorMessage: null,
-  loading: false,
-  definitions: []
+  datafiles: {
+    list: [],
+    error: false,
+    errorMessage: null,
+    loading: false,
+    defaultHost: ''
+  },
+  definitions: {
+    list: [],
+    error: false,
+    errorMessage: null,
+    loading: true
+  }
 };
 
 export const addSystemDefinition = (system, definitionList) => {
@@ -19,45 +26,63 @@ export function systems(state = initialSystemState, action) {
     case 'FETCH_SYSTEMS_STARTED':
       return {
         ...state,
-        error: false,
-        errorMessage: null,
-        loading: true
+        datafiles: {
+          ...state.datafiles,
+          error: false,
+          errorMessage: null,
+          loading: true
+        }
       };
     case 'FETCH_SYSTEMS_SUCCESS':
       return {
         ...state,
-        systemList: action.payload.system_list,
-        defaultHost: action.payload.default_host,
-        loading: false
+        datafiles: {
+          ...state.datafiles,
+          list: action.payload.system_list,
+          defaultHost: action.payload.default_host,
+          loading: false
+        }
       };
     case 'FETCH_SYSTEMS_ERROR':
       return {
         ...state,
-        error: true,
-        errorMessage: action.payload,
-        loading: false
+        datafiles: {
+          ...state.datafiles,
+          error: true,
+          errorMessage: action.payload,
+          loading: false
+        }
       };
     case 'FETCH_SYSTEM_DEFINITION_STARTED':
       return {
         ...state,
-        error: false,
-        errorMessage: null,
-        loading: true
+        definitions: {
+          ...state.datafiles,
+          error: false,
+          errorMessage: null,
+          loading: true
+        }
       };
     case 'FETCH_SYSTEM_DEFINITION_SUCCESS':
       return {
         ...state,
-        definitions: addSystemDefinition(action.payload, state.definitions),
-        error: false,
-        errorMessage: null,
-        loading: false
+        definitions: {
+          ...state.datafiles,
+          list: addSystemDefinition(action.payload, state.definitions),
+          error: false,
+          errorMessage: null,
+          loading: false
+        }
       };
     case 'FETCH_SYSTEM_DEFINITION_ERROR':
       return {
         ...state,
-        error: true,
-        errorMessage: action.payload,
-        loading: false
+        definitions: {
+          ...state.datafiles,
+          error: true,
+          errorMessage: action.payload,
+          loading: false
+        }
       };
     default:
       return state;

--- a/client/src/utils/systems.test.js
+++ b/client/src/utils/systems.test.js
@@ -4,51 +4,66 @@ import {
   findProjectTitle,
   findSystemOrProjectDisplayName
 } from './systems';
-import systemsFixture from '../components/DataFiles/fixtures/DataFiles.systems.fixture'
-import { projectsListingFixture } from '../redux/sagas/fixtures/projects.fixture'
-
+import systemsFixture from '../components/DataFiles/fixtures/DataFiles.systems.fixture';
+import { projectsListingFixture } from '../redux/sagas/fixtures/projects.fixture';
 
 describe('systems utility functions', () => {
   it('get system name from host', () => {
     expect(getSystemName('stampede2.tacc.utexas.edu')).toEqual('Stampede2');
   });
   it('get system display name from host', () => {
-    const systemList = systemsFixture.systemList;
-    expect(findSystemDisplayName(systemList, 'frontera.home.username')).toEqual('My Data (Frontera)');
-    expect(findSystemDisplayName(systemList, 'frontera.foo.bar')).toEqual('Frontera');
+    const { list: systemList } = systemsFixture.datafiles;
+    expect(findSystemDisplayName(systemList, 'frontera.home.username')).toEqual(
+      'My Data (Frontera)'
+    );
+    expect(findSystemDisplayName(systemList, 'frontera.foo.bar')).toEqual(
+      'Frontera'
+    );
   });
   it('get project title from host', () => {
-    expect(findProjectTitle(projectsListingFixture, 'test.site.project.FRONTERA-3')).toEqual('Test Project Title');
-    expect(findProjectTitle(projectsListingFixture, 'test.site.project.FRONTERA-X')).toEqual('Shared Workspaces');
+    expect(
+      findProjectTitle(projectsListingFixture, 'test.site.project.FRONTERA-3')
+    ).toEqual('Test Project Title');
+    expect(
+      findProjectTitle(projectsListingFixture, 'test.site.project.FRONTERA-X')
+    ).toEqual('Shared Workspaces');
   });
   it('get project title based on resource', () => {
-    const systemList = systemsFixture.systemList;
-    expect(findSystemOrProjectDisplayName(
-      'projects',
-      systemList,
-      projectsListingFixture,
-      'test.site.project.FRONTERA-3'
-    )).toEqual('Test Project Title');
-    expect(findSystemOrProjectDisplayName(
-      'projects',
-      systemList,
-      projectsListingFixture,
-      'test.site.project.FRONTERA-X'
-    )).toEqual('Shared Workspaces');
+    const { list: systemList } = systemsFixture.datafiles;
+    expect(
+      findSystemOrProjectDisplayName(
+        'projects',
+        systemList.datafiles,
+        projectsListingFixture,
+        'test.site.project.FRONTERA-3'
+      )
+    ).toEqual('Test Project Title');
+    expect(
+      findSystemOrProjectDisplayName(
+        'projects',
+        systemList,
+        projectsListingFixture,
+        'test.site.project.FRONTERA-X'
+      )
+    ).toEqual('Shared Workspaces');
   });
   it('get system display name based on resource', () => {
-    const systemList = systemsFixture.systemList;
-    expect(findSystemOrProjectDisplayName(
-      'private',
-      systemList,
-      projectsListingFixture,
-      'frontera.home.username'
-    )).toEqual('My Data (Frontera)');
-    expect(findSystemOrProjectDisplayName(
-      'private',
-      systemList,
-      projectsListingFixture,
-      'frontera.foo.bar'
-    )).toEqual('Frontera');
+    const { list: systemList } = systemsFixture.datafiles;
+    expect(
+      findSystemOrProjectDisplayName(
+        'private',
+        systemList,
+        projectsListingFixture,
+        'frontera.home.username'
+      )
+    ).toEqual('My Data (Frontera)');
+    expect(
+      findSystemOrProjectDisplayName(
+        'private',
+        systemList,
+        projectsListingFixture,
+        'frontera.foo.bar'
+      )
+    ).toEqual('Frontera');
   });
 });

--- a/client/src/utils/systems.test.js
+++ b/client/src/utils/systems.test.js
@@ -12,7 +12,7 @@ describe('systems utility functions', () => {
     expect(getSystemName('stampede2.tacc.utexas.edu')).toEqual('Stampede2');
   });
   it('get system display name from host', () => {
-    const { list: systemList } = systemsFixture.datafiles;
+    const { configuration: systemList } = systemsFixture.storage;
     expect(findSystemDisplayName(systemList, 'frontera.home.username')).toEqual(
       'My Data (Frontera)'
     );
@@ -29,11 +29,11 @@ describe('systems utility functions', () => {
     ).toEqual('Shared Workspaces');
   });
   it('get project title based on resource', () => {
-    const { list: systemList } = systemsFixture.datafiles;
+    const { configuration: systemList } = systemsFixture.storage;
     expect(
       findSystemOrProjectDisplayName(
         'projects',
-        systemList.datafiles,
+        systemList,
         projectsListingFixture,
         'test.site.project.FRONTERA-3'
       )
@@ -48,7 +48,7 @@ describe('systems utility functions', () => {
     ).toEqual('Shared Workspaces');
   });
   it('get system display name based on resource', () => {
-    const { list: systemList } = systemsFixture.datafiles;
+    const { configuration: systemList } = systemsFixture.storage;
     expect(
       findSystemOrProjectDisplayName(
         'private',


### PR DESCRIPTION
## Overview: ##

If there is a delay in getting a user's systems ([FP-866](https://jira.tacc.utexas.edu/browse/FP-866)) then we show an empty list of systems.  This PR handles those delays by:
* showing a spinner in Datafiles until the system information is received
* ensuring that allocation error message doesn't show up for an app doesn't show up because we are still waiting for systems

## Related Jira tickets: ##

* [FP-866](https://jira.tacc.utexas.edu/browse/FP-866)
* [FP-869](https://jira.tacc.utexas.edu/browse/FP-869)

## Summary of Changes: ##
* Refactor redux datafiles systems and definitions state so they have independent loading/error variables
* Handle loading/error of systems in `Datafiles` component
* Wait for `systems.datafiles.defaultHost` to be received before showing an allocation error message

## Testing Steps: ##
Test the handling of delayed systems request
1. Force systems listing to be slow by adding `import time; time.sleep(3)` to listing in `server/portal/apps/datafiles/views.py` (line 51)
2. Refresh on datafiles and ensure things work well
3. Refresh on Frontera app (`https://cep.dev/workbench/applications/frontera-hpc-jupyter-1.0u12`) and ensure that an allocation error message isn't displayed
4. (optional)Use an account missing Frontera allocation and try step 3 to make sure that the allocation error *is* displayed 

Test the handling of error in the system request
1. Force systems listing to be slow by adding 
`from portal.exceptions.api import ApiException; raise ApiException("dummy")`
 to listing in `server/portal/apps/datafiles/views.py` (line 51)
2. See the error (see screenshot below)

## UI Photos:
![Screen Shot 2021-01-27 at 7 14 40 PM](https://user-images.githubusercontent.com/8287580/106075855-0fd6ca00-60d4-11eb-9928-2e9045837939.png)

![Screen Shot 2021-01-28 at 12 09 07 PM](https://user-images.githubusercontent.com/8287580/106180480-f5e3c880-6161-11eb-8400-8316fdc0a0db.png)


## Notes: ##
TODO
- [x] Consult with Design about styling of error message in DataFiles