### PR TITLE
Shared Workspaces breadcrumb fixes: Load project title on page refresh

### DIFF
--- a/client/src/components/DataFiles/DataFilesBreadcrumbs/DataFilesBreadcrumbs.js
+++ b/client/src/components/DataFiles/DataFilesBreadcrumbs/DataFilesBreadcrumbs.js
@@ -84,6 +84,7 @@ const DataFilesBreadcrumbs = ({
   const pathComps = [];
   const systemList = useSelector(state => state.systems.systemList);
   const projectsList = useSelector(state => state.projects.listing.projects);
+  const projectTitle = useSelector(state => state.projects.metadata.title);
 
   path
     .split('/')
@@ -99,7 +100,8 @@ const DataFilesBreadcrumbs = ({
     scheme,
     systemList,
     projectsList,
-    system
+    system,
+    projectTitle
   );
 
   return (
@@ -112,7 +114,7 @@ const DataFilesBreadcrumbs = ({
           >
             Shared Workspaces
           </Link>{' '}
-          /{' '}
+          {system && `/ `}
         </>
       )}
       <BreadcrumbLink

--- a/client/src/components/PublicData/PublicData.test.js
+++ b/client/src/components/PublicData/PublicData.test.js
@@ -32,11 +32,13 @@ describe('PublicData', () => {
       projects: {
         listing: {
           projects: []
+        },
+        metadata: {
+          title: ''
         }
       },
       pushKeys: { target: {} }
     });
-    console.log(filesFixture);
     const { getByText, getAllByText, debug } = renderComponent(
       <PublicData />,
       store,

--- a/client/src/utils/systems.js
+++ b/client/src/utils/systems.js
@@ -42,12 +42,12 @@ export function findSystemDisplayName(systemList, system, isRoot) {
  * @return {string} project title
  */
 
-export function findProjectTitle(projectsList, projectSystem) {
+export function findProjectTitle(projectsList, projectSystem, projectTitle) {
   const matching = projectsList.find(project => project.id === projectSystem);
   if (matching) {
     return matching.description;
   }
-  return '';
+  return projectSystem ? projectTitle : '';
 }
 
 /**
@@ -63,11 +63,12 @@ export function findSystemOrProjectDisplayName(
   scheme,
   systemList,
   projectsList,
-  system
+  system,
+  projectTitle
 ) {
   switch (scheme) {
     case 'projects':
-      return findProjectTitle(projectsList, system);
+      return findProjectTitle(projectsList, system, projectTitle);
     default:
       return findSystemDisplayName(systemList, system);
   }

--- a/client/src/utils/systems.js
+++ b/client/src/utils/systems.js
@@ -47,7 +47,7 @@ export function findProjectTitle(projectsList, projectSystem, projectTitle) {
   if (matching) {
     return matching.description;
   }
-  return projectSystem ? projectTitle : '';
+  return projectSystem && projectTitle ? projectTitle : '';
 }
 
 /**

--- a/client/src/utils/systems.test.js
+++ b/client/src/utils/systems.test.js
@@ -17,9 +17,9 @@ describe('systems utility functions', () => {
     expect(findSystemDisplayName(systemList, 'frontera.home.username')).toEqual('My Data (Frontera)');
     expect(findSystemDisplayName(systemList, 'frontera.foo.bar')).toEqual('Frontera');
   });
-  it('get project title from host', () => {
+  it('get project title from host or project metadata', () => {
     expect(findProjectTitle(projectsListingFixture, 'test.site.project.FRONTERA-3')).toEqual('Test Project Title');
-    expect(findProjectTitle(projectsListingFixture, 'test.site.project.FRONTERA-X')).toEqual('');
+    expect(findProjectTitle(projectsListingFixture, 'test.site.project.FRONTERA-X', 'Test Project Title')).toEqual('Test Project Title');
   });
   it('get project title based on resource', () => {
     const systemList = systemsFixture.systemList;
@@ -33,8 +33,9 @@ describe('systems utility functions', () => {
       'projects',
       systemList,
       projectsListingFixture,
-      'test.site.project.FRONTERA-X'
-    )).toEqual('');
+      'test.site.project.FRONTERA-X',
+      'Test Project Title'
+    )).toEqual('Test Project Title');
   });
   it('get system display name based on resource', () => {
     const systemList = systemsFixture.systemList;

--- a/client/src/utils/systems.test.js
+++ b/client/src/utils/systems.test.js
@@ -40,6 +40,19 @@ describe('systems utility functions', () => {
       'projects',
       systemList,
       projectsListingFixture,
+      'test.site.project.FRONTERA-X'
+    )).toEqual('');
+    expect(findSystemOrProjectDisplayName(
+      'projects',
+      systemList,
+      projectsListingFixture,
+      '',
+      'Test Project Title'
+    )).toEqual('');
+    expect(findSystemOrProjectDisplayName(
+      'projects',
+      systemList,
+      projectsListingFixture,
       'test.site.project.FRONTERA-X',
       null
     )).toEqual('');

--- a/client/src/utils/systems.test.js
+++ b/client/src/utils/systems.test.js
@@ -36,6 +36,13 @@ describe('systems utility functions', () => {
       'test.site.project.FRONTERA-X',
       'Test Project Title'
     )).toEqual('Test Project Title');
+    expect(findSystemOrProjectDisplayName(
+      'projects',
+      systemList,
+      projectsListingFixture,
+      'test.site.project.FRONTERA-X',
+      null
+    )).toEqual('');
   });
   it('get system display name based on resource', () => {
     const systemList = systemsFixture.systemList;


### PR DESCRIPTION
## Overview: ##
- Loads project breadcrumb for project title, even when page is refreshed
- Hide trailing "/" after "Shared Workspaces" in breadcrumbs if no project is selected

## Testing Steps: ##
1. Go to https://cep.dev/workbench/data/tapis/projects/
2. Ensure no trailing `"/"` shows
3. Navigate into a project and ensure `"/"` now shows
4. Refresh page and ensure Project Title still shows in breadcrumbs

## UI Photos:
<img width="472" alt="Screen Shot 2021-01-27 at 2 22 29 PM" src="https://user-images.githubusercontent.com/20326896/106048928-1bfa6180-60ab-11eb-8631-729708040b8d.png">
