### PR TITLE
Quick: Clarify Message prop deprecation warning

### DIFF
--- a/client/src/components/_common/Message/Message.js
+++ b/client/src/components/_common/Message/Message.js
@@ -7,9 +7,9 @@ import './Message.module.scss';
 
 export const ERROR_TEXT = {
   mismatchCanDismissScope:
-    'For a <Message> to use `canDismiss`, `scope` must equal `section`.',
+    'For a <(Section)Message> to use `canDismiss`, `scope` must equal `section`.',
   deprecatedType:
-    'In a <Message> `type="warn"` is deprecated. Use `type="warning"` instead.',
+    'In a <(Section|Inline)Message> `type="warn"` is deprecated. Use `type="warning"` instead.',
   missingScope:
     'A <Message> without a `scope` should become an <InlineMessage>. (If <Message> must be used, then explicitely set `scope="inline"`.)'
 };


### PR DESCRIPTION
## Overview: ##

Improve prop deprecation message to respect component used which generated the message.

## Related Jira tickets: ##

* N/A

## Summary of Changes: ##

- ___Fix__: Change `<Message>` warning texts to suggest `<SectionMessage>` or `<InlineMessage>` could have been used.

## Testing Steps: ##
1. Receive `<Message>` log message.
2. Notice that it is now `<(Section|Inline)Message>` or `<(Section)Message>`.

## UI Photos:

(skipped)

## Notes: ##
